### PR TITLE
Refine absorption dynamics with Lucas–Washburn decay

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,14 @@
 import { useMemo, useState } from 'react'
 import { Leva, button, useControls } from 'leva'
 import WatercolorViewport from '@/components/watercolor/WatercolorViewport'
-import { DEFAULT_BINDER_PARAMS, type BrushType, type SimulationParams } from '@/lib/watercolor/WatercolorSimulation'
+import {
+  DEFAULT_ABSORB_EXPONENT,
+  DEFAULT_ABSORB_MIN_FLUX,
+  DEFAULT_ABSORB_TIME_OFFSET,
+  DEFAULT_BINDER_PARAMS,
+  type BrushType,
+  type SimulationParams,
+} from '@/lib/watercolor/WatercolorSimulation'
 
 type Tool = 'water' | 'pigment0' | 'pigment1' | 'pigment2'
 
@@ -169,6 +176,9 @@ export default function Home() {
     backrunStrength,
     stateAbsorption,
     granulation,
+    absorbExponent: DEFAULT_ABSORB_EXPONENT,
+    absorbTimeOffset: DEFAULT_ABSORB_TIME_OFFSET,
+    absorbMinFlux: DEFAULT_ABSORB_MIN_FLUX,
     cfl,
     maxSubsteps,
     binder: {


### PR DESCRIPTION
## Summary
- expose Lucas–Washburn absorption coefficients through `SimulationParams` and default exports
- update the absorb shader and uniform plumbing to use √t decay with time accumulation and floors
- track cumulative absorb time in the simulation loop and relax it on new splats to keep diffusion stable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb430fe25c8326900a9de4fb821735