### PR TITLE
Refactor watercolor solver to GPU LBM pipeline

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,104 +1,89 @@
 # Watercolor Simulation Overview
 
-This document describes the simulation implemented in the Next.js/react-three-fiber prototype. The current build implements the following roadmap items:
+The watercolor engine now drives flow using a GPU-resident Lattice Boltzmann (LBM) solver. A D2Q9 BGK scheme evolves the fluid
+velocity field on a square lattice, while scalar fields for water height, pigment load, binder concentration, and paper wetness
+are advected and diffused on the same grid. Deposition and drying still follow the Lucas–Washburn model so the system preserves
+the visual language of watercolor washes while moving the heavy computation to shader passes.
 
-- Pressure projection to maintain a divergence-free velocity field.
-- Anisotropic paper diffusion driven by a procedurally generated fibre texture.
-- State-dependent absorption and evaporation tied to paper wetness and water height.
-- Granulation via a settled pigment reservoir that feeds into deposition.
-- Backruns/Blooms that emphasise advancing wet edges using the wetness gradient.
-- CFL-based adaptive timestep with automatic sub-stepping when velocities spike.
-- Finite-thickness Kubelka–Munk composite with adjustable layer scale.
+## Simulation State
 
-## State Fields
-
-| Symbol | Texture | Description |
-| ------ | ------- | ----------- |
-| `H` | ping-pong RGBA16F | Water height (R channel). |
-| `UV` | ping-pong RGBA16F | Surface velocity (RG). |
-| `C` | ping-pong RGBA16F | Dissolved pigment carried by the flow (RGB). |
-| `DEP` | ping-pong RGBA16F | Pigment deposited on the paper (RGB). |
-| `W` | ping-pong RGBA16F | Paper wetness / retained moisture (R). |
-| `S` | ping-pong RGBA16F | Settled pigment reservoir used for granulation (RGB). |
-| `KM` | single RGBA16F | Kubelka–Munk composite colour rendered to screen. |
-|
-
-All simulation textures use half floats so they remain filterable on WebGL2.
+- **LBM distributions** – Two ping-ponged `WebGLMultipleRenderTargets` keep the nine LBM distribution values (`f0 … f8`) encoded
+  as three RGBA buffers. Each step streams the values from neighbours, collides toward equilibrium, and rescales to match the
+  current water height.
+- **Height/binder/pigment/wetness** – Ping-pong render targets (`H`, `B`, `C`, `W`) store the film thickness, binder content,
+  pigment concentration, and paper wetness respectively. Height doubles as the Lucas–Washburn source term and guides the LBM
+  pressure gradient.
+- **Deposits and settled pigment** – Two more ping-pong textures (`DEP`, `S`) accumulate pigment fixed to the paper surface and
+  the temporarily settled fraction used for granulation.
+- **Velocity texture** – A single render target caches the macroscopic velocity extracted from the LBM distributions for use in
+  semi-Lagrangian advection passes and CFL diagnostics.
+- **Paper fibers** – A procedurally generated `DataTexture` encodes anisotropic diffusion coefficients so wetness can wick along
+  implied paper grain.
+- **Composite target** – The Kubelka–Munk composite shader still shades the final deposits texture into display space.
 
 ## Frame Pipeline
 
-1. **Splat (brush injection)**  
-   Injects water and optionally pigment using a Gaussian falloff. A radial velocity push is added to mimic brush agitation. Parameters come from the Leva "Brush" controls.
+1. **Brush splat** – Water splats add to the height field while pigment splats additionally inject colour and binder according to
+   the configured binder injection strength.
+2. **LBM step** – A single collision/stream pass pulls neighbour distributions, applies a gravity-driven pressure gradient derived
+   from the height field, modulates viscosity with binder concentration, and relaxes toward equilibrium. The resulting state is
+   converted into a velocity/density texture in a follow-up pass.
+3. **Binder advection & relaxation** – Binder is semi-Lagrangian advected by the new velocity field, diffused with a Laplacian, and
+   decays toward zero. Binder viscosity feeds back into the next LBM solve.
+4. **Height transport** – Water height is advected by the velocity field and nudged by binder buoyancy to simulate slightly tacky
+   pigment mixtures.
+5. **Pigment advection and diffusion** – Pigment follows the velocity field then diffuses via a Fickian Laplacian pass to soften
+   colour boundaries.
+6. **Absorption & evaporation** – Five shader passes reuse a shared Lucas–Washburn routine to update deposits, remaining height,
+   pigment load, wetness, and settled pigment. The shader supports humidity-based modulation, an absorb-rate floor, and a
+   pseudo time-offset factor to emulate the \(1 / \sqrt{t}\) decay from the reference model.
+7. **Paper diffusion** – Wetness diffuses anisotropically along the fibre map, allowing backruns and blooms to travel outward.
+8. **Composite** – Deposited pigment drives the Kubelka–Munk layer shader to produce the visible colour.
 
-2. **Pressure projection (Stam 1999)**  
-   An unsteady velocity field is projected onto a divergence-free subspace by solving the Poisson equation `∇²p = div(u) / dt` (20 Jacobi iterations). The gradient of `p` is subtracted from `u` to enforce incompressibility. This stabilises edge flows and keeps puddles from expanding indefinitely.
+## LBM Details
 
-3. **Advection**  
-   Semi-Lagrangian advection transports `H` and `C` using the updated velocity. Velocity is also damped by viscosity and accelerated by the surface gradient term `u += -dt * g * ∇h`.
-   Before each frame, the solver measures the current maximum velocity magnitude via a GPU reduction. If `dt` violates the configured CFL safety bound, it subdivides the frame into multiple substeps (up to `maxSubsteps`) to keep `|u|·dt ≤ cfl·dx`.
+- The solver uses the standard D2Q9 velocity set with BGK relaxation. Distribution storage is normalised such that the macroscopic
+  density equals `LBM_BASE_DENSITY + height`, letting the height field drive pressure gradients.
+- Binder acts as a viscosity booster by raising the local relaxation time before collision, slowing down heavy paint and letting
+  thin washes flow freely.
+- Gravity couples into the flow by sampling the water-height gradient and applying the resulting force during collision.
 
-4. **Absorption / Evaporation / Granulation**  
-   The absorb pass now evaluates per-pixel rates:
+## Absorption Controls
 
-   - Absorption: `A = A₀ * (1 - w)^{β}` with exponent `β = 1.4`, encouraging drier paper to pull in more water.
-   - Evaporation: `E = E₀ * √h * mix(1, 1 - w, λ)` with `λ = 0.6`, reducing evaporation on saturated paper.
-   - Granulation reservoir: a percentage `v_settle * dt` of the remaining dissolved pigment enters the settled buffer `S` before deposition.
-   - Deposition: dissolved pigment plus the settled reservoir feed a depth factor `k_dep = depBase + granStrength * edgeBias` to reinforce pigment along ridges (`edgeBias ∝ |∇h|`). The deposited mass is subtracted from both dissolved and settled pools proportionally.
-   - Blooms/backruns: positive wetness gradients (`max(w - w_neighbor, 0)`) scale an extra deposit term `k_back` so advancing fronts leave cauliflower blooms. The strength comes from the "Backrun Strength" slider and clamps itself to the available dissolved pigment.
+- `absorb` sets the base Lucas–Washburn flux. When `stateAbsorption` is enabled the shader multiplies the flux by
+  `(1 - wet)^β / √(wet + absorbTimeOffset)`, giving a humidity-sensitive, diminishing-rate absorption profile. `absorbMinFlux`
+  clamps the result so extremely thin films still dry numerically.
+- `evap` controls evaporation strength. The shader mixes evaporation with humidity so soaked paper evaporates slowly.
+- `edge`, `granulation`, and `backrunStrength` behave as in the previous implementation, boosting pigment deposition at ridges and
+  optionally redistributing pigment from the suspended and settled reservoirs.
 
-   The pass outputs updated `DEP`, `H`, `C`, `W`, and `S` using separate raw-shader materials fed with the same uniforms.
+## Module Layout
 
-5. **Anisotropic paper diffusion**  
-   After absorption the wetness buffer is diffused using an oriented tensor field derived from a procedural fibre texture. The shader samples `(cosθ, sinθ, d∥, d⊥)` per texel and integrates `w_t = ∇·(D ∇w) + replenish`, nudging water along the grain while replenishing drier paper with a portion of the absorbed water.
+- `lib/watercolor/WatercolorSimulation.ts` – Orchestrates render targets, LBM passes, scalar advection, absorption, and final
+  compositing.
+- `lib/watercolor/materials.ts` – Builds the RawShaderMaterials for splats, LBM passes, advection, diffusion, absorption, and
+  compositing.
+- `lib/watercolor/shaders.ts` – Contains the GLSL snippets for the fullscreen quad, LBM kernels, diffusion, absorption, and
+  Kubelka–Munk composite.
+- `lib/watercolor/constants.ts` – Shared numerical constants, pigment optics parameters, and default binder/absorption values.
+- `lib/watercolor/targets.ts` – Helpers for configuring render targets and ping-pong structures.
+- `lib/watercolor/types.ts` – Shared TypeScript interfaces for brushes, binder parameters, simulation parameters, and the
+  material map.
 
-6. **Composite (Finite-thickness Kubelka–Munk)**  
-   Deposited pigment produces absorption `K` and scattering `S` coefficients. We approximate finite thickness by scaling both coefficients with the accumulated pigment mass (controlled by `KM_LAYER_SCALE`) before evaluating the infinite-layer KM solution. This darkens layered pigment while keeping the formulation numerically stable on WebGL.
+## Parameter Mapping
 
-## Granulation Reservoir (`S`)
+UI controls map onto the simulation as follows:
 
-The settled buffer captures pigment that precipitates but has not yet bonded to the paper surface. Settling is proportional to dissolved pigment (`S += v_settle * C * dt`), while deposition draws from both dissolved and settled pigment. This produces the darker grainy rims characteristic of traditional watercolour granulation.
-
-## Parameter Controls
-
-Leva UI folders map to the simulation parameters:
-
-- **Brush**: tool, radius, and flow. Pigment tools map to CMY pigment reservoirs.
-- **Drying & Deposits**: base absorption `A₀`, evaporation `E₀`, edge bias strength, and backrun intensity (`k_back`).
-- **Flow Dynamics**: gravity, viscosity, CFL safety factor, and maximum substeps for adaptive timestepping.
-- **Brush Reservoir**: capacity and consumption sliders for water/pigment charge and stamp spacing.
-- **Simulation Features**: toggles for state-dependent drying and granulation, useful when isolating regressions.
-
-Global constants (tuned empirically) control the exponents, humidity coupling, settle rate, and granulation strength. They can be adjusted in `WatercolorSimulation.ts` if different paper styles are desired.
-
-## Shaders
-
-| Stage | Shader constant | Notes |
-| ----- | --------------- | ----- |
-| Brush splat | `SPLAT_*` | Adds water/pigment and radial velocity. |
-| Advection | `ADVECT_*` | Semi-Lagrangian transport with slope-driven acceleration. |
-| Absorption suite | `ABSORB_*` | Shared helper `computeAbsorb()` calculates state-dependent rates and granulation. |
-| Pressure solve | `PRESSURE_*` | Divergence, Jacobi, and projection passes. |
-| Paper diffusion | `PAPER_DIFFUSION_FRAGMENT` | Anisotropic diffusion along fibres with replenish term. |
-| Composite | `COMPOSITE_FRAGMENT` | Kubelka–Munk reflectance shading. |
-
-## Implementation Notes
-
-- RawShaderMaterial is used for all compute shaders to avoid three.js shader chunk injection and to work directly with `#version 300 es` WebGL2 shaders.
-- Ping-pong render targets (`createPingPong`) are used for every mutable field so that reads and writes remain disjoint.
-- The fibre texture is generated procedurally as a `DataTexture`, encoding orientation and diffusion coefficients for each texel. This avoids additional assets and keeps the grain reproducible.
-- Finite-thickness KM uses a tunable layer scale (`KM_LAYER_SCALE`) that maps deposited pigment mass to optical thickness, with hyperbolic formulations to avoid the infinite-layer shortcut.
-- Granulation and diffusion rely on constants tuned for stability on half-float buffers; extreme parameter values may demand higher iteration counts or clamping adjustments.
+- **Flow dynamics** – `grav`, `visc`, `cfl`, and `maxSubsteps` feed the LBM solver, affecting the gravity force, base viscosity,
+  and adaptive sub-stepping.
+- **Drying** – `absorb`, `absorbExponent`, `absorbTimeOffset`, `absorbMinFlux`, `stateAbsorption`, `evap`, and `backrunStrength`
+  configure the Lucas–Washburn and evaporation passes.
+- **Binder** – `SimulationParams.binder` governs binder injection, diffusion, decay, viscosity boost, and buoyancy.
+- **Pigment diffusion** – `PIGMENT_DIFFUSION_COEFF` is exposed in the code and can be tuned to adjust how quickly colours soften.
+- **Granulation** – The granulation toggle activates settled-pigment transfer and noise-based deposition boosts.
 
 ## References
 
-- Stam, J. *Stable Fluids*, SIGGRAPH 1999. (advection & projection)
-- Curtis, C., Anderson, S., Seims, J. *Computer Generated Watercolor*, SIGGRAPH 1997. (deposition & edge darkening)
-- Deegan, R. D. et al. *Capillary flow as the cause of ring stains from dried liquid drops*, Nature 1997. (coffee-ring effect)
-- Kubelka, P., Munk, F. *Ein Beitrag zur Optik der Farbanstriche*, 1931. (KM reflectance)
-- Lucas, R. (1918), Washburn, E. W. (1921). *Capillary flow in porous media*. (absorption law)
-
-
-
-
-
-
+- Qian, Y. H., d'Humières, D., Lallemand, P. “Lattice BGK Models for Navier–Stokes Equation.” *Europhysics Letters*, 1992.
+- Mi You et al. “Realistic Paint Simulation Based on Fluidity, Diffusion, and Absorption.” *Computer Animation and Virtual Worlds*, 2013.
+- Lucas, R. (1918), Washburn, E. W. (1921). “Capillary flow in porous media.”

--- a/lib/watercolor/WatercolorSimulation.ts
+++ b/lib/watercolor/WatercolorSimulation.ts
@@ -1,669 +1,34 @@
 import * as THREE from 'three'
 
-// GPU-driven watercolor solver combining shallow-water flow, pigment transport, and paper optics.
-export type BrushType = 'water' | 'pigment'
+import { createMaterials } from './materials'
+import {
+  createLBMPingPong,
+  createPingPong,
+  createRenderTarget,
+  type PingPongTarget,
+} from './targets'
+import {
+  DEFAULT_ABSORB_EXPONENT,
+  DEFAULT_ABSORB_MIN_FLUX,
+  DEFAULT_ABSORB_TIME_OFFSET,
+  DEFAULT_BINDER_PARAMS,
+  DEFAULT_DT,
+  DEPOSITION_BASE,
+  GRANULATION_SETTLE_RATE,
+  GRANULATION_STRENGTH,
+  HUMIDITY_INFLUENCE,
+  PAPER_DIFFUSION_STRENGTH,
+  PIGMENT_DIFFUSION_COEFF,
+} from './constants'
+import {
+  type BinderParams,
+  type BrushSettings,
+  type MaterialMap,
+  type SimulationParams,
+} from './types'
 
-export interface BrushSettings {
-  center: [number, number]
-  radius: number
-  flow: number
-  type: BrushType
-  color: [number, number, number]
-}
+const EPSILON = 1e-6
 
-export interface BinderParams {
-  injection: number
-  diffusion: number
-  decay: number
-  elasticity: number
-  viscosity: number
-  buoyancy: number
-}
-
-export interface SimulationParams {
-  grav: number
-  visc: number
-  absorb: number
-  evap: number
-  edge: number
-  stateAbsorption: boolean
-  granulation: boolean
-  backrunStrength: number
-  absorbExponent: number
-  absorbTimeOffset: number
-  absorbMinFlux: number
-  cfl: number
-  maxSubsteps: number
-  binder: BinderParams
-  reservoir: {
-    waterCapacityWater: number
-    waterCapacityPigment: number
-    pigmentCapacity: number
-    waterConsumption: number
-    pigmentConsumption: number
-    stampSpacing: number
-  }
-}
-
-// Convenience wrapper for render targets that alternate between read/write.
-type PingPongTarget = {
-  read: THREE.WebGLRenderTarget
-  write: THREE.WebGLRenderTarget
-  swap: () => void
-}
-
-// Shared GLSL utilities for the screen-space simulation steps.
-const FULLSCREEN_VERTEX = `
-in vec3 position;
-in vec2 uv;
-out vec2 vUv;
-void main() {
-  vUv = uv;
-  gl_Position = vec4(position.xy, 0.0, 1.0);
-}
-`
-
-const ZERO_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-void main() {
-  fragColor = vec4(0.0);
-}
-`
-
-const SPLAT_COMMON = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uSource;
-uniform vec2 uCenter;
-uniform float uRadius;
-uniform float uFlow;
-float splatFalloff(vec2 uv, float radius) {
-  vec2 delta = uv - uCenter;
-  float r = max(radius, 1e-6);
-  return exp(-9.0 * dot(delta, delta) / (r * r + 1e-6));
-}
-`
-
-const SPLAT_HEIGHT_FRAGMENT = `
-${SPLAT_COMMON}
-uniform float uToolType;
-void main() {
-  vec4 src = texture(uSource, vUv);
-  float fall = splatFalloff(vUv, uRadius);
-  float waterMul = mix(1.0, 0.7, step(0.5, uToolType));
-  src.r += waterMul * uFlow * fall;
-  fragColor = vec4(src.r, 0.0, 0.0, 1.0);
-}
-`
-
-const SPLAT_VELOCITY_FRAGMENT = `
-${SPLAT_COMMON}
-void main() {
-  vec4 src = texture(uSource, vUv);
-  vec2 delta = vUv - uCenter;
-  float fall = splatFalloff(vUv, uRadius);
-  float len = length(delta);
-  vec2 dir = len > 1e-6 ? delta / len : vec2(0.0);
-  vec2 dv = dir * (0.7 * uFlow * fall);
-  fragColor = vec4(src.xy + dv, 0.0, 1.0);
-}
-`
-
-const SPLAT_PIGMENT_FRAGMENT = `
-${SPLAT_COMMON}
-uniform float uToolType;
-uniform vec3 uPigment;
-void main() {
-  vec4 src = texture(uSource, vUv);
-  float fall = splatFalloff(vUv, uRadius);
-  float pigmentMask = step(0.5, uToolType);
-  vec3 add = uPigment * (uFlow * fall * pigmentMask);
-  fragColor = vec4(src.rgb + add, src.a);
-}
-`
-
-const SPLAT_BINDER_FRAGMENT = `
-${SPLAT_COMMON}
-uniform float uToolType;
-uniform float uBinderStrength;
-void main() {
-  vec4 src = texture(uSource, vUv);
-  float fall = splatFalloff(vUv, uRadius);
-  float mask = step(0.5, uToolType);
-  float add = uBinderStrength * uFlow * fall * mask;
-  fragColor = vec4(src.r + add, 0.0, 0.0, 1.0);
-}
-`
-
-const ADVECT_VELOCITY_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uHeight;
-uniform sampler2D uVelocity;
-uniform float uDt;
-uniform float uGrav;
-uniform float uVisc;
-uniform vec2 uTexel;
-vec2 sampleGrad(vec2 uv) {
-  float hm = texture(uHeight, uv - vec2(uTexel.x, 0.0)).r;
-  float hp = texture(uHeight, uv + vec2(uTexel.x, 0.0)).r;
-  float hm2 = texture(uHeight, uv - vec2(0.0, uTexel.y)).r;
-  float hp2 = texture(uHeight, uv + vec2(0.0, uTexel.y)).r;
-  return vec2((hp - hm) * 0.5, (hp2 - hm2) * 0.5);
-}
-void main() {
-  vec2 vel = texture(uVelocity, vUv).xy;
-  vec2 grad = sampleGrad(vUv);
-  vel += -uDt * uGrav * grad;
-  vel *= (1.0 - uVisc * uDt);
-  fragColor = vec4(vel, 0.0, 1.0);
-}
-`
-
-const ADVECT_HEIGHT_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uHeight;
-uniform sampler2D uVelocity;
-uniform sampler2D uBinder;
-uniform float uDt;
-uniform float uBinderBuoyancy;
-void main() {
-  vec2 vel = texture(uVelocity, vUv).xy;
-  vec2 back = vUv - uDt * vel;
-  vec4 sample_color = texture(uHeight, back);
-  float binder = texture(uBinder, vUv).r;
-  float newH = max(sample_color.r + uBinderBuoyancy * binder * uDt, 0.0);
-  fragColor = vec4(newH, 0.0, 0.0, 1.0);
-}
-`
-
-const ADVECT_PIGMENT_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uPigment;
-uniform sampler2D uVelocity;
-uniform float uDt;
-void main() {
-  vec2 vel = texture(uVelocity, vUv).xy;
-  vec2 back = vUv - uDt * vel;
-  vec4 sample_color = texture(uPigment, back);
-  fragColor = vec4(max(sample_color.rgb, vec3(0.0)), sample_color.a);
-}
-`
-
-const PIGMENT_DIFFUSION_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uPigment;
-uniform vec2 uTexel;
-uniform float uDiffusion;
-uniform float uDt;
-
-vec3 sampleRGB(vec2 uv) {
-  return texture(uPigment, uv).rgb;
-}
-
-void main() {
-  vec4 center = texture(uPigment, vUv);
-  vec2 du = vec2(uTexel.x, 0.0);
-  vec2 dv = vec2(0.0, uTexel.y);
-  vec3 left = sampleRGB(vUv - du);
-  vec3 right = sampleRGB(vUv + du);
-  vec3 bottom = sampleRGB(vUv - dv);
-  vec3 top = sampleRGB(vUv + dv);
-  vec3 laplacian = left + right + top + bottom - 4.0 * center.rgb;
-  vec3 diffused = center.rgb + uDiffusion * laplacian * uDt;
-  fragColor = vec4(max(diffused, vec3(0.0)), center.a);
-}
-`
-
-const ADVECT_BINDER_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uBinder;
-uniform sampler2D uVelocity;
-uniform vec2 uTexel;
-uniform float uDt;
-uniform float uDiffusion;
-uniform float uDecay;
-
-float sampleBinder(vec2 coord) {
-  return texture(uBinder, coord).r;
-}
-
-void main() {
-  vec2 vel = texture(uVelocity, vUv).xy;
-  vec2 back = vUv - uDt * vel;
-  float binder = texture(uBinder, back).r;
-  float left = sampleBinder(vUv - vec2(uTexel.x, 0.0));
-  float right = sampleBinder(vUv + vec2(uTexel.x, 0.0));
-  float bottom = sampleBinder(vUv - vec2(0.0, uTexel.y));
-  float top = sampleBinder(vUv + vec2(0.0, uTexel.y));
-  float lap = left + right + top + bottom - 4.0 * binder;
-  binder += uDiffusion * lap * uDt;
-  binder = max(binder - uDecay * uDt, 0.0);
-  fragColor = vec4(binder, 0.0, 0.0, 1.0);
-}
-`
-
-const BINDER_FORCE_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uVelocity;
-uniform sampler2D uBinder;
-uniform vec2 uTexel;
-uniform float uDt;
-uniform float uElasticity;
-uniform float uViscosity;
-
-vec2 binderGradient(vec2 uv) {
-  float left = texture(uBinder, uv - vec2(uTexel.x, 0.0)).r;
-  float right = texture(uBinder, uv + vec2(uTexel.x, 0.0)).r;
-  float bottom = texture(uBinder, uv - vec2(0.0, uTexel.y)).r;
-  float top = texture(uBinder, uv + vec2(0.0, uTexel.y)).r;
-  return vec2(right - left, top - bottom) * 0.5;
-}
-
-void main() {
-  vec2 vel = texture(uVelocity, vUv).xy;
-  float binder = texture(uBinder, vUv).r;
-  vec2 grad = binderGradient(vUv);
-  vec2 springForce = -uElasticity * grad;
-  vel += springForce * uDt;
-  float damping = clamp(uViscosity * binder * uDt, 0.0, 0.95);
-  vel *= (1.0 - damping);
-  fragColor = vec4(vel, 0.0, 1.0);
-}
-`
-
-const ABSORB_COMMON = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uHeight;
-uniform sampler2D uPigment;
-uniform sampler2D uWet;
-uniform sampler2D uDeposits;
-uniform sampler2D uSettled;
-uniform float uAbsorb;
-uniform float uEvap;
-uniform float uEdge;
-uniform float uDepBase;
-uniform float uBeta;
-uniform float uAbsorbTime;
-uniform float uAbsorbTimeOffset;
-uniform float uAbsorbFloor;
-uniform float uHumidity;
-uniform float uSettle;
-uniform float uGranStrength;
-uniform float uBackrunStrength;
-uniform vec2 uTexel;
-
-struct AbsorbResult {
-  float newH;
-  float newWet;
-  vec3 pigment;
-  vec3 dep;
-  vec3 settled;
-};
-
-AbsorbResult computeAbsorb(vec2 uv) {
-  AbsorbResult res;
-  float h = texture(uHeight, uv).r;
-  vec3 pigment = texture(uPigment, uv).rgb;
-  float wet = texture(uWet, uv).r;
-  vec3 dep = texture(uDeposits, uv).rgb;
-  vec3 settled = texture(uSettled, uv).rgb;
-
-  vec2 du = vec2(uTexel.x, 0.0);
-  vec2 dv = vec2(0.0, uTexel.y);
-  float hx = texture(uHeight, uv + du).r - texture(uHeight, uv - du).r;
-  float hy = texture(uHeight, uv + dv).r - texture(uHeight, uv - dv).r;
-  float edgeBias = uEdge * 0.5 * sqrt(hx * hx + hy * hy);
-
-  float wL = texture(uWet, uv - du).r;
-  float wR = texture(uWet, uv + du).r;
-  float wB = texture(uWet, uv - dv).r;
-  float wT = texture(uWet, uv + dv).r;
-  float outwardDiff = max(wet - wL, 0.0) + max(wet - wR, 0.0) + max(wet - wB, 0.0) + max(wet - wT, 0.0);
-  float edgeAdvance = max(outwardDiff * 0.25 - 0.05, 0.0);
-  float bloomFactor = clamp(uBackrunStrength * edgeAdvance, 0.0, 1.0) * step(1e-5, h);
-
-  float humidity = clamp(1.0 - wet, 0.0, 1.0);
-  float humidityFactor = pow(humidity, uBeta);
-  float timeTerm = max(uAbsorbTime + uAbsorbTimeOffset, 1e-4);
-  float decay = inversesqrt(timeTerm);
-  float baseAbsorb = max(uAbsorb * decay, uAbsorbFloor);
-  float absorbAmount = baseAbsorb * humidityFactor;
-  float evapBase = uEvap * sqrt(max(h, 0.0));
-  float evapRate = evapBase * mix(1.0, humidity, uHumidity);
-  float totalOut = absorbAmount + evapRate;
-
-  float newH = max(h - totalOut, 0.0);
-  float remRaw = totalOut / max(h, 1e-6);
-  if (h <= 1e-6) {
-    remRaw = 1.0;
-  }
-  float remFrac = clamp(min(1.0, remRaw), 0.0, 1.0);
-  float depFrac = clamp(remFrac * (0.5 + edgeBias) + uDepBase * edgeBias, 0.0, 1.0);
-  vec3 depAdd = pigment * depFrac;
-  dep += depAdd;
-  pigment = max(pigment - depAdd, vec3(0.0));
-
-  vec3 bloomDep = pigment * bloomFactor;
-  dep += bloomDep;
-  pigment = max(pigment - bloomDep, vec3(0.0));
-
-  float settleRate = clamp(uSettle, 0.0, 1.0);
-  vec3 settleAdd = pigment * settleRate;
-  pigment = max(pigment - settleAdd, vec3(0.0));
-  vec3 settledNew = settled + settleAdd;
-
-  float granCoeff = clamp(uGranStrength * edgeBias, 0.0, 1.0);
-  vec3 granSource = pigment + settledNew;
-  vec3 granDep = granSource * granCoeff;
-  vec3 totalSource = max(granSource, vec3(1e-5));
-  vec3 fromPigment = granDep * (pigment / totalSource);
-  vec3 fromSettled = granDep * (settledNew / totalSource);
-  pigment = max(pigment - fromPigment, vec3(0.0));
-  settledNew = max(settledNew - fromSettled, vec3(0.0));
-  dep += granDep;
-
-  float newWet = clamp(wet + absorbAmount, 0.0, 1.0);
-
-  res.newH = newH;
-  res.newWet = newWet;
-  res.pigment = pigment;
-  res.dep = dep;
-  res.settled = settledNew;
-  return res;
-}
-`;
-
-const VELOCITY_MAX_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uVelocity;
-uniform vec2 uTexel;
-
-float velocityMag(vec2 coord) {
-  vec2 vel = texture(uVelocity, coord).xy;
-  return length(vel);
-}
-
-void main() {
-  vec2 halfStep = 0.5 * uTexel;
-  float m = velocityMag(vUv);
-  m = max(m, velocityMag(vUv + vec2(-halfStep.x, -halfStep.y)));
-  m = max(m, velocityMag(vUv + vec2(halfStep.x, -halfStep.y)));
-  m = max(m, velocityMag(vUv + vec2(-halfStep.x, halfStep.y)));
-  m = max(m, velocityMag(vUv + vec2(halfStep.x, halfStep.y)));
-  fragColor = vec4(m, 0.0, 0.0, 1.0);
-}
-`;
-
-const ABSORB_DEPOSIT_FRAGMENT = `
-${ABSORB_COMMON}
-void main() {
-  AbsorbResult res = computeAbsorb(vUv);
-  fragColor = vec4(res.dep, 1.0);
-}
-`;
-
-const ABSORB_HEIGHT_FRAGMENT = `
-${ABSORB_COMMON}
-void main() {
-  AbsorbResult res = computeAbsorb(vUv);
-  fragColor = vec4(res.newH, 0.0, 0.0, 1.0);
-}
-`;
-
-const ABSORB_PIGMENT_FRAGMENT = `
-${ABSORB_COMMON}
-void main() {
-  AbsorbResult res = computeAbsorb(vUv);
-  fragColor = vec4(res.pigment, 1.0);
-}
-`;
-
-const ABSORB_WET_FRAGMENT = `
-${ABSORB_COMMON}
-void main() {
-  AbsorbResult res = computeAbsorb(vUv);
-  fragColor = vec4(res.newWet, 0.0, 0.0, 1.0);
-}
-`;
-
-const ABSORB_SETTLED_FRAGMENT = `
-${ABSORB_COMMON}
-void main() {
-  AbsorbResult res = computeAbsorb(vUv);
-  fragColor = vec4(res.settled, 1.0);
-}
-`;
-
-const PRESSURE_DIVERGENCE_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uVelocity;
-uniform vec2 uTexel;
-void main() {
-  float left = texture(uVelocity, vUv - vec2(uTexel.x, 0.0)).x;
-  float right = texture(uVelocity, vUv + vec2(uTexel.x, 0.0)).x;
-  float bottom = texture(uVelocity, vUv - vec2(0.0, uTexel.y)).y;
-  float top = texture(uVelocity, vUv + vec2(0.0, uTexel.y)).y;
-  float divergence = 0.5 * ((right - left) + (top - bottom));
-  fragColor = vec4(divergence, 0.0, 0.0, 1.0);
-}
-`;
-
-const PRESSURE_JACOBI_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uPressure;
-uniform sampler2D uDivergence;
-uniform vec2 uTexel;
-void main() {
-  float left = texture(uPressure, vUv - vec2(uTexel.x, 0.0)).r;
-  float right = texture(uPressure, vUv + vec2(uTexel.x, 0.0)).r;
-  float bottom = texture(uPressure, vUv - vec2(0.0, uTexel.y)).r;
-  float top = texture(uPressure, vUv + vec2(0.0, uTexel.y)).r;
-  float divergence = texture(uDivergence, vUv).r;
-  float pressure = (left + right + top + bottom - divergence) * 0.25;
-  fragColor = vec4(pressure, 0.0, 0.0, 1.0);
-}
-`;
-
-const PRESSURE_PROJECT_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uVelocity;
-uniform sampler2D uPressure;
-uniform vec2 uTexel;
-void main() {
-  float left = texture(uPressure, vUv - vec2(uTexel.x, 0.0)).r;
-  float right = texture(uPressure, vUv + vec2(uTexel.x, 0.0)).r;
-  float bottom = texture(uPressure, vUv - vec2(0.0, uTexel.y)).r;
-  float top = texture(uPressure, vUv + vec2(0.0, uTexel.y)).r;
-  vec2 vel = texture(uVelocity, vUv).xy;
-  vec2 gradient = vec2(right - left, top - bottom) * 0.5;
-  vec2 projected = vel - gradient;
-  fragColor = vec4(projected, 0.0, 1.0);
-}
-`;
-const PAPER_DIFFUSION_FRAGMENT = `
-
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uWet;
-uniform sampler2D uFiber;
-uniform vec2 uTexel;
-uniform float uDt;
-uniform float uReplenish;
-uniform float uStrength;
-void main() {
-  vec4 fiber = texture(uFiber, vUv);
-  vec2 dir = fiber.xy;
-  if (dot(dir, dir) < 1e-6) {
-    dir = vec2(1.0, 0.0);
-  } else {
-    dir = normalize(dir);
-  }
-  vec2 dirTex = dir * uTexel;
-  vec2 perp = vec2(-dir.y, dir.x);
-  vec2 perpTex = perp * uTexel;
-
-  float w = texture(uWet, vUv).r;
-  float wParaPlus = texture(uWet, vUv + dirTex).r;
-  float wParaMinus = texture(uWet, vUv - dirTex).r;
-  float wPerpPlus = texture(uWet, vUv + perpTex).r;
-  float wPerpMinus = texture(uWet, vUv - perpTex).r;
-
-  float dPara = fiber.z;
-  float dPerp = fiber.w;
-  float lap = dPara * (wParaPlus - 2.0 * w + wParaMinus) + dPerp * (wPerpPlus - 2.0 * w + wPerpMinus);
-  float diffusion = uStrength * lap;
-  float replenish = uReplenish * (1.0 - w);
-  float newW = clamp(w + uDt * (diffusion + replenish), 0.0, 1.0);
-  fragColor = vec4(newW, 0.0, 0.0, 1.0);
-}
-`;
-const COMPOSITE_FRAGMENT = `
-precision highp float;
-in vec2 vUv;
-out vec4 fragColor;
-uniform sampler2D uDeposits;
-uniform vec3 uPaper;
-uniform vec3 uK[3];
-uniform vec3 uS[3];
-uniform float uLayerScale;
-
-vec3 infiniteLayer(vec3 K, vec3 S) {
-  vec3 safeS = max(S, vec3(1e-3));
-  vec3 r = 1.0 + K / safeS;
-  vec3 disc = max(r * r - vec3(1.0), vec3(0.0));
-  return clamp(r - sqrt(disc), vec3(0.0), vec3(1.0));
-}
-
-void main() {
-  vec3 dep = texture(uDeposits, vUv).rgb;
-  vec3 K = dep.r * uK[0] + dep.g * uK[1] + dep.b * uK[2];
-  vec3 S = vec3(0.4) + dep.r * uS[0] + dep.g * uS[1] + dep.b * uS[2];
-  float density = dot(dep, vec3(1.0));
-  float layerK = 1.0 + uLayerScale * density;
-  float layerS = 1.0 + 0.5 * uLayerScale * density;
-  vec3 R = infiniteLayer(K * layerK, S * layerS);
-  vec3 col = clamp(R * uPaper, vec3(0.0), vec3(1.0));
-  fragColor = vec4(col, 1.0);
-}
-`;
-
-// Tunable constants describing the paper model and numerical scheme.
-const DEFAULT_DT = 1 / 90
-const DEPOSITION_BASE = 0.02
-const PAPER_COLOR = new THREE.Vector3(0.92, 0.91, 0.88)
-const PAPER_DIFFUSION_STRENGTH = 6.0
-const PIGMENT_DIFFUSION_COEFF = 0.08
-const KM_LAYER_SCALE = 1.4
-export const DEFAULT_ABSORB_EXPONENT = 0.5
-export const DEFAULT_ABSORB_TIME_OFFSET = 0.15
-export const DEFAULT_ABSORB_MIN_FLUX = 0.02
-const HUMIDITY_INFLUENCE = 0.6
-const GRANULATION_SETTLE_RATE = 0.28
-const GRANULATION_STRENGTH = 0.45
-const PIGMENT_K = [
-  new THREE.Vector3(1.6, 0.1, 0.1),
-  new THREE.Vector3(0.1, 1.4, 0.15),
-  new THREE.Vector3(0.05, 0.1, 1.2),
-] as const
-const PIGMENT_S = [
-  new THREE.Vector3(0.5, 0.55, 0.6),
-  new THREE.Vector3(0.55, 0.45, 0.5),
-  new THREE.Vector3(0.6, 0.55, 0.35),
-] as const
-
-export const DEFAULT_BINDER_PARAMS: BinderParams = {
-  injection: 0.65,
-  diffusion: 0.12,
-  decay: 0.08,
-  elasticity: 1.25,
-  viscosity: 0.65,
-  buoyancy: 0.12,
-}
-
-// Cache RawShaderMaterials reused across simulation passes.
-type MaterialMap = {
-  zero: THREE.RawShaderMaterial
-  splatHeight: THREE.RawShaderMaterial
-  splatVelocity: THREE.RawShaderMaterial
-  splatPigment: THREE.RawShaderMaterial
-  splatBinder: THREE.RawShaderMaterial
-  advectVelocity: THREE.RawShaderMaterial
-  advectHeight: THREE.RawShaderMaterial
-  advectPigment: THREE.RawShaderMaterial
-  diffusePigment: THREE.RawShaderMaterial
-  advectBinder: THREE.RawShaderMaterial
-  binderForces: THREE.RawShaderMaterial
-  absorbDeposit: THREE.RawShaderMaterial
-  absorbHeight: THREE.RawShaderMaterial
-  absorbPigment: THREE.RawShaderMaterial
-  absorbWet: THREE.RawShaderMaterial
-  absorbSettled: THREE.RawShaderMaterial
-  diffuseWet: THREE.RawShaderMaterial
-  composite: THREE.RawShaderMaterial
-  divergence: THREE.RawShaderMaterial
-  jacobi: THREE.RawShaderMaterial
-  project: THREE.RawShaderMaterial
-}
-
-// Helper to build render targets with consistent filtering and wrapping.
-function createRenderTarget(size: number, type: THREE.TextureDataType) {
-  const target = new THREE.WebGLRenderTarget(size, size, {
-    type,
-    format: THREE.RGBAFormat,
-    depthBuffer: false,
-    stencilBuffer: false,
-    magFilter: THREE.LinearFilter,
-    minFilter: THREE.LinearFilter,
-  })
-  target.texture.generateMipmaps = false
-  target.texture.wrapS = THREE.ClampToEdgeWrapping
-  target.texture.wrapT = THREE.ClampToEdgeWrapping
-  target.texture.colorSpace = THREE.NoColorSpace
-  return target
-}
-
-// Pair of render targets that can swap roles between passes.
-function createPingPong(size: number, type: THREE.TextureDataType): PingPongTarget {
-  const a = createRenderTarget(size, type)
-  const b = createRenderTarget(size, type)
-  return {
-    read: a,
-    write: b,
-    swap() {
-      const temp = this.read
-      this.read = this.write
-      this.write = temp
-    },
-  }
-}
-
-// Procedural paper fiber map introduces anisotropic wetness diffusion.
 function createFiberField(size: number): THREE.DataTexture {
   const data = new Float32Array(size * size * 4)
   for (let y = 0; y < size; y += 1) {
@@ -674,14 +39,14 @@ function createFiberField(size: number): THREE.DataTexture {
       const nx = u - 0.5
       const ny = v - 0.5
       const swirl = Math.sin((nx + ny) * Math.PI * 4.0)
-      const wave = Math.cos((nx * 6.0) - (ny * 5.0))
+      const wave = Math.cos(nx * 6.0 - ny * 5.0)
       const angle = Math.atan2(ny, nx + 1e-6) * 0.35 + swirl * 0.6
       const dirX = Math.cos(angle)
       const dirY = Math.sin(angle)
       const dPara = 0.7 + 0.25 * wave
       const dPerp = 0.18 + 0.12 * Math.sin((nx - ny) * Math.PI * 6.0)
-      data[idx + 0] = dirX
-      data[idx + 1] = dirY
+      data[idx + 0] = 0.5 * (dirX + 1.0)
+      data[idx + 1] = 0.5 * (dirY + 1.0)
       data[idx + 2] = Math.max(0.2, dPara)
       data[idx + 3] = Math.max(0.05, dPerp)
     }
@@ -695,51 +60,37 @@ function createFiberField(size: number): THREE.DataTexture {
   texture.colorSpace = THREE.NoColorSpace
   return texture
 }
-// Construct a RawShaderMaterial using the shared fullscreen vertex shader.
-function createMaterial(fragmentShader: string, uniforms: Record<string, THREE.IUniform>): THREE.RawShaderMaterial {
-  const sanitizeShader = (code: string) => code.trimStart()
 
-  return new THREE.RawShaderMaterial({
-    uniforms,
-    vertexShader: sanitizeShader(FULLSCREEN_VERTEX),
-    fragmentShader: sanitizeShader(fragmentShader),
-    glslVersion: THREE.GLSL3,
-    depthTest: false,
-    depthWrite: false,
-    blending: THREE.NoBlending,
-  })
-}
+type RenderTargetLike = THREE.WebGLRenderTarget | THREE.WebGLMultipleRenderTargets
 
-// WatercolorSimulation coordinates all render passes and exposes a simple API.
+type FluidTargets = PingPongTarget<THREE.WebGLMultipleRenderTargets>
+
+type ScalarTargets = PingPongTarget<THREE.WebGLRenderTarget>
+
 export default class WatercolorSimulation {
   private readonly renderer: THREE.WebGLRenderer
   private readonly size: number
   private readonly texelSize: THREE.Vector2
-  private readonly targets: {
-    H: PingPongTarget
-    UV: PingPongTarget
-    C: PingPongTarget
-    B: PingPongTarget
-    DEP: PingPongTarget
-    W: PingPongTarget
-    S: PingPongTarget
-  }
-  private readonly compositeTarget: THREE.WebGLRenderTarget
   private readonly scene: THREE.Scene
   private readonly camera: THREE.OrthographicCamera
   private readonly quad: THREE.Mesh<THREE.PlaneGeometry, THREE.RawShaderMaterial>
   private readonly materials: MaterialMap
   private readonly fiberTexture: THREE.DataTexture
-  private readonly pressure: PingPongTarget
-  private readonly divergence: THREE.WebGLRenderTarget
-  private readonly pressureIterations = 20
+  private readonly fluid: FluidTargets
+  private readonly targets: {
+    H: ScalarTargets
+    C: ScalarTargets
+    B: ScalarTargets
+    DEP: ScalarTargets
+    W: ScalarTargets
+    S: ScalarTargets
+  }
+  private readonly velocityTarget: THREE.WebGLRenderTarget
+  private readonly compositeTarget: THREE.WebGLRenderTarget
   private readonly velocityReductionTargets: THREE.WebGLRenderTarget[]
-  private readonly velocityMaxMaterial: THREE.RawShaderMaterial
   private readonly velocityReadBuffer = new Float32Array(4)
   private binderSettings: BinderParams
-  private absorbElapsed = 0
 
-  // Set up render targets, materials, and state needed for the solver.
   constructor(renderer: THREE.WebGLRenderer, size = 512) {
     if (!renderer.capabilities.isWebGL2) {
       throw new Error('WatercolorSimulation requires a WebGL2 context')
@@ -751,30 +102,28 @@ export default class WatercolorSimulation {
 
     const textureType = renderer.capabilities.isWebGL2 ? THREE.HalfFloatType : THREE.FloatType
 
+    this.materials = createMaterials(size)
+    this.fiberTexture = createFiberField(size)
+
+    this.fluid = createLBMPingPong(size, textureType)
     this.targets = {
       H: createPingPong(size, textureType),
-      UV: createPingPong(size, textureType),
       C: createPingPong(size, textureType),
       B: createPingPong(size, textureType),
       DEP: createPingPong(size, textureType),
       W: createPingPong(size, textureType),
       S: createPingPong(size, textureType),
     }
+
+    this.velocityTarget = createRenderTarget(size, textureType)
     this.compositeTarget = createRenderTarget(size, textureType)
-    this.pressure = createPingPong(size, textureType)
-    this.divergence = createRenderTarget(size, textureType)
-    this.fiberTexture = createFiberField(size)
+    this.velocityReductionTargets = this.createVelocityReductionTargets(textureType)
 
     this.scene = new THREE.Scene()
     this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
-
-    this.materials = this.createMaterials()
-
     this.quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), this.materials.zero)
     this.scene.add(this.quad)
 
-    this.velocityMaxMaterial = this.createVelocityMaxMaterial()
-    this.velocityReductionTargets = this.createVelocityReductionTargets(size)
     this.binderSettings = { ...DEFAULT_BINDER_PARAMS }
 
     this.reset()
@@ -784,524 +133,325 @@ export default class WatercolorSimulation {
     return this.compositeTarget.texture
   }
 
-  // Inject water or pigment into the simulation at a given position.
-  splat(brush: BrushSettings) {
-    const { center, radius, flow, type, color } = brush
-    const toolType = type === 'water' ? 0 : 1
+  reset() {
+    const zero = this.materials.zero
+    this.renderToTarget(zero, this.targets.H.read)
+    this.renderToTarget(zero, this.targets.H.write)
+    this.renderToTarget(zero, this.targets.C.read)
+    this.renderToTarget(zero, this.targets.C.write)
+    this.renderToTarget(zero, this.targets.B.read)
+    this.renderToTarget(zero, this.targets.B.write)
+    this.renderToTarget(zero, this.targets.DEP.read)
+    this.renderToTarget(zero, this.targets.DEP.write)
+    this.renderToTarget(zero, this.targets.W.read)
+    this.renderToTarget(zero, this.targets.W.write)
+    this.renderToTarget(zero, this.targets.S.read)
+    this.renderToTarget(zero, this.targets.S.write)
+    this.renderToTarget(zero, this.velocityTarget)
+    this.renderToTarget(zero, this.compositeTarget)
 
-    const splatHeight = this.materials.splatHeight
-    splatHeight.uniforms.uSource.value = this.targets.H.read.texture
-    splatHeight.uniforms.uCenter.value.set(center[0], center[1])
-    splatHeight.uniforms.uRadius.value = radius
-    splatHeight.uniforms.uFlow.value = flow
-    splatHeight.uniforms.uToolType.value = toolType
-    this.renderToTarget(splatHeight, this.targets.H.write)
-    this.targets.H.swap()
-
-    const splatVelocity = this.materials.splatVelocity
-    splatVelocity.uniforms.uSource.value = this.targets.UV.read.texture
-    splatVelocity.uniforms.uCenter.value.set(center[0], center[1])
-    splatVelocity.uniforms.uRadius.value = radius
-    splatVelocity.uniforms.uFlow.value = flow
-    this.renderToTarget(splatVelocity, this.targets.UV.write)
-    this.targets.UV.swap()
-
-
-    const splatPigment = this.materials.splatPigment
-    splatPigment.uniforms.uSource.value = this.targets.C.read.texture
-    splatPigment.uniforms.uCenter.value.set(center[0], center[1])
-    splatPigment.uniforms.uRadius.value = radius
-    splatPigment.uniforms.uFlow.value = flow
-    splatPigment.uniforms.uToolType.value = toolType
-    splatPigment.uniforms.uPigment.value.set(color[0], color[1], color[2])
-    this.renderToTarget(splatPigment, this.targets.C.write)
-    this.targets.C.swap()
-
-    const splatBinder = this.materials.splatBinder
-    splatBinder.uniforms.uSource.value = this.targets.B.read.texture
-    splatBinder.uniforms.uCenter.value.set(center[0], center[1])
-    splatBinder.uniforms.uRadius.value = radius
-    splatBinder.uniforms.uFlow.value = flow
-    splatBinder.uniforms.uToolType.value = toolType
-    splatBinder.uniforms.uBinderStrength.value = this.binderSettings.injection
-    this.renderToTarget(splatBinder, this.targets.B.write)
-    this.targets.B.swap()
-
-    const absorbReset = toolType === 0 ? 0.3 : 0.15
-    this.absorbElapsed = Math.max(0, this.absorbElapsed - absorbReset * flow)
-  }
-
-  // Run one simulation step using semi-Lagrangian advection and absorption.
-  step(params: SimulationParams, dt = DEFAULT_DT) {
-    const {
-      grav,
-      visc,
-      absorb,
-      evap,
-      edge,
-      stateAbsorption,
-      granulation,
-      backrunStrength,
-      absorbExponent,
-      absorbTimeOffset,
-      absorbMinFlux,
-      cfl,
-      maxSubsteps,
-      binder,
-    } = params
-
-    this.binderSettings = { ...binder }
-
-    const substeps = this.determineSubsteps(cfl, maxSubsteps, dt)
-    const substepDt = dt / substeps
-
-    for (let i = 0; i < substeps; i += 1) {
-      const advectBinder = this.materials.advectBinder
-      advectBinder.uniforms.uBinder.value = this.targets.B.read.texture
-      advectBinder.uniforms.uVelocity.value = this.targets.UV.read.texture
-      advectBinder.uniforms.uDt.value = substepDt
-      advectBinder.uniforms.uDiffusion.value = binder.diffusion
-      advectBinder.uniforms.uDecay.value = binder.decay
-      this.renderToTarget(advectBinder, this.targets.B.write)
-      this.targets.B.swap()
-
-      const binderForces = this.materials.binderForces
-      binderForces.uniforms.uVelocity.value = this.targets.UV.read.texture
-      binderForces.uniforms.uBinder.value = this.targets.B.read.texture
-      binderForces.uniforms.uDt.value = substepDt
-      binderForces.uniforms.uElasticity.value = binder.elasticity
-      binderForces.uniforms.uViscosity.value = binder.viscosity
-      this.renderToTarget(binderForces, this.targets.UV.write)
-      this.targets.UV.swap()
-
-      const advectVel = this.materials.advectVelocity
-      advectVel.uniforms.uHeight.value = this.targets.H.read.texture
-      advectVel.uniforms.uVelocity.value = this.targets.UV.read.texture
-      advectVel.uniforms.uDt.value = substepDt
-      advectVel.uniforms.uGrav.value = grav
-      advectVel.uniforms.uVisc.value = visc
-      this.renderToTarget(advectVel, this.targets.UV.write)
-      this.targets.UV.swap()
-      this.projectVelocity()
-
-      const advectHeight = this.materials.advectHeight
-      advectHeight.uniforms.uHeight.value = this.targets.H.read.texture
-      advectHeight.uniforms.uVelocity.value = this.targets.UV.read.texture
-      advectHeight.uniforms.uBinder.value = this.targets.B.read.texture
-      advectHeight.uniforms.uBinderBuoyancy.value = binder.buoyancy
-      advectHeight.uniforms.uDt.value = substepDt
-      this.renderToTarget(advectHeight, this.targets.H.write)
-      this.targets.H.swap()
-
-      const advectPigment = this.materials.advectPigment
-      advectPigment.uniforms.uPigment.value = this.targets.C.read.texture
-      advectPigment.uniforms.uVelocity.value = this.targets.UV.read.texture
-      advectPigment.uniforms.uDt.value = substepDt
-      this.renderToTarget(advectPigment, this.targets.C.write)
-      this.targets.C.swap()
-
-      const diffusePigment = this.materials.diffusePigment
-      diffusePigment.uniforms.uPigment.value = this.targets.C.read.texture
-      diffusePigment.uniforms.uDiffusion.value = PIGMENT_DIFFUSION_COEFF
-      diffusePigment.uniforms.uDt.value = substepDt
-      this.renderToTarget(diffusePigment, this.targets.C.write)
-      this.targets.C.swap()
-
-      const absorbBase = absorb * substepDt
-      const evapFactor = evap * substepDt
-      const edgeFactor = edge * substepDt
-      const beta = stateAbsorption ? absorbExponent : 1.0
-      const humidityInfluence = stateAbsorption ? HUMIDITY_INFLUENCE : 0.0
-      const settleBase = granulation ? GRANULATION_SETTLE_RATE : 0.0
-      const granStrength = granulation ? GRANULATION_STRENGTH : 0.0
-      const settleFactor = settleBase * substepDt
-      const timeOffset = stateAbsorption ? Math.max(absorbTimeOffset, 1e-4) : 1.0
-      const absorbTime = stateAbsorption ? this.absorbElapsed + 0.5 * substepDt : 0
-      const absorbFloor = stateAbsorption ? Math.max(absorbMinFlux, 0) * substepDt : 0
-      const decay = stateAbsorption ? 1 / Math.sqrt(absorbTime + timeOffset) : 1
-      const paperReplenish = absorbBase * decay
-
-      const absorbDeposit = this.materials.absorbDeposit
-      this.assignAbsorbUniforms(
-        absorbDeposit,
-        absorbBase,
-        evapFactor,
-        edgeFactor,
-        settleFactor,
-        beta,
-        humidityInfluence,
-        granStrength,
-        backrunStrength,
-        absorbTime,
-        timeOffset,
-        absorbFloor,
-      )
-      this.renderToTarget(absorbDeposit, this.targets.DEP.write)
-
-      const absorbHeight = this.materials.absorbHeight
-      this.assignAbsorbUniforms(
-        absorbHeight,
-        absorbBase,
-        evapFactor,
-        edgeFactor,
-        settleFactor,
-        beta,
-        humidityInfluence,
-        granStrength,
-        backrunStrength,
-        absorbTime,
-        timeOffset,
-        absorbFloor,
-      )
-      this.renderToTarget(absorbHeight, this.targets.H.write)
-
-      const absorbPigment = this.materials.absorbPigment
-      this.assignAbsorbUniforms(
-        absorbPigment,
-        absorbBase,
-        evapFactor,
-        edgeFactor,
-        settleFactor,
-        beta,
-        humidityInfluence,
-        granStrength,
-        backrunStrength,
-        absorbTime,
-        timeOffset,
-        absorbFloor,
-      )
-      this.renderToTarget(absorbPigment, this.targets.C.write)
-
-      const absorbWet = this.materials.absorbWet
-      this.assignAbsorbUniforms(
-        absorbWet,
-        absorbBase,
-        evapFactor,
-        edgeFactor,
-        settleFactor,
-        beta,
-        humidityInfluence,
-        granStrength,
-        backrunStrength,
-        absorbTime,
-        timeOffset,
-        absorbFloor,
-      )
-      this.renderToTarget(absorbWet, this.targets.W.write)
-
-      const absorbSettled = this.materials.absorbSettled
-      this.assignAbsorbUniforms(
-        absorbSettled,
-        absorbBase,
-        evapFactor,
-        edgeFactor,
-        settleFactor,
-        beta,
-        humidityInfluence,
-        granStrength,
-        backrunStrength,
-        absorbTime,
-        timeOffset,
-        absorbFloor,
-      )
-      this.renderToTarget(absorbSettled, this.targets.S.write)
-
-      this.targets.DEP.swap()
-      this.targets.H.swap()
-      this.targets.C.swap()
-      this.targets.W.swap()
-      this.targets.S.swap()
-
-      this.applyPaperDiffusion(substepDt, paperReplenish)
-      if (stateAbsorption) {
-        this.absorbElapsed += substepDt
-      } else {
-        this.absorbElapsed = 0
-      }
-    }
+    const lbmInit = this.materials.lbmInit
+    this.renderToTarget(lbmInit, this.fluid.read)
+    this.renderToTarget(lbmInit, this.fluid.write)
 
     const composite = this.materials.composite
     composite.uniforms.uDeposits.value = this.targets.DEP.read.texture
     this.renderToTarget(composite, this.compositeTarget)
   }
 
-  // Diffuse moisture along the paper fiber field to keep edges alive.
-  private applyPaperDiffusion(dt: number, replenish: number) {
-    const diffuse = this.materials.diffuseWet
-    diffuse.uniforms.uWet.value = this.targets.W.read.texture
-    diffuse.uniforms.uDt.value = dt
-    diffuse.uniforms.uReplenish.value = replenish
-    this.renderToTarget(diffuse, this.targets.W.write)
-    this.targets.W.swap()
-  }
-
-
-  // Enforce incompressibility by solving a pressure Poisson equation.
-  private projectVelocity() {
-    const divergence = this.materials.divergence
-    divergence.uniforms.uVelocity.value = this.targets.UV.read.texture
-    this.renderToTarget(divergence, this.divergence)
-
-    const zero = this.materials.zero
-    this.renderToTarget(zero, this.pressure.read)
-    this.renderToTarget(zero, this.pressure.write)
-
-    const jacobi = this.materials.jacobi
-    jacobi.uniforms.uDivergence.value = this.divergence.texture
-    for (let i = 0; i < this.pressureIterations; i += 1) {
-      jacobi.uniforms.uPressure.value = this.pressure.read.texture
-      this.renderToTarget(jacobi, this.pressure.write)
-      this.pressure.swap()
-    }
-
-    const project = this.materials.project
-    project.uniforms.uVelocity.value = this.targets.UV.read.texture
-    project.uniforms.uPressure.value = this.pressure.read.texture
-    this.renderToTarget(project, this.targets.UV.write)
-    this.targets.UV.swap()
-  }
-
-  // Clear all render targets so the canvas returns to a blank state.
-  reset() {
-    this.clearPingPong(this.targets.H)
-    this.clearPingPong(this.targets.UV)
-    this.clearPingPong(this.targets.C)
-    this.clearPingPong(this.targets.B)
-    this.clearPingPong(this.targets.DEP)
-    this.clearPingPong(this.targets.W)
-    this.clearPingPong(this.targets.S)
-    this.clearPingPong(this.pressure)
-    this.renderToTarget(this.materials.zero, this.divergence)
-    this.renderToTarget(this.materials.zero, this.compositeTarget)
-    this.absorbElapsed = 0
-  }
-
-  // Release GPU allocations when the simulation is no longer needed.
   dispose() {
     this.quad.geometry.dispose()
-    Object.values(this.materials).forEach((mat) => mat.dispose())
-    this.velocityMaxMaterial.dispose()
-    this.clearTargets()
+    Object.values(this.materials).forEach((material) => material.dispose())
     this.fiberTexture.dispose()
+    this.velocityTarget.dispose()
+    this.compositeTarget.dispose()
+    this.fluid.read.dispose()
+    this.fluid.write.dispose()
+    Object.values(this.targets).forEach((target) => {
+      target.read.dispose()
+      target.write.dispose()
+    })
     this.velocityReductionTargets.forEach((target) => target.dispose())
   }
 
-  // Dispose both read/write targets to avoid leaking GPU textures.
-  private clearTargets() {
-    this.targets.H.read.dispose()
-    this.targets.H.write.dispose()
-    this.targets.UV.read.dispose()
-    this.targets.UV.write.dispose()
-    this.targets.C.read.dispose()
-    this.targets.C.write.dispose()
-    this.targets.B.read.dispose()
-    this.targets.B.write.dispose()
-    this.targets.DEP.read.dispose()
-    this.targets.DEP.write.dispose()
-    this.targets.W.read.dispose()
-    this.targets.W.write.dispose()
-    this.targets.S.read.dispose()
-    this.targets.S.write.dispose()
-    this.pressure.read.dispose()
-    this.pressure.write.dispose()
-    this.divergence.dispose()
-    this.compositeTarget.dispose()
-  }
+  splat(brush: BrushSettings) {
+    const { center, radius, flow, type, color } = brush
+    const toolType = type === 'pigment' ? 1 : 0
 
-  // Fill both buffers of a ping-pong target with zeros.
-  private clearPingPong(target: PingPongTarget) {
-    this.renderToTarget(this.materials.zero, target.read)
-    this.renderToTarget(this.materials.zero, target.write)
-  }
+    const centerVec = new THREE.Vector2(center[0], center[1])
 
-  // Render a fullscreen quad with the provided material into a target.
-  private renderToTarget(material: THREE.RawShaderMaterial, target: THREE.WebGLRenderTarget | null) {
-    const previousTarget = this.renderer.getRenderTarget()
-    const previousAutoClear = this.renderer.autoClear
+    const splatHeight = this.materials.splatHeight
+    splatHeight.uniforms.uSource.value = this.targets.H.read.texture
+    splatHeight.uniforms.uCenter.value.copy(centerVec)
+    splatHeight.uniforms.uRadius.value = radius
+    splatHeight.uniforms.uFlow.value = flow
+    splatHeight.uniforms.uToolType.value = toolType
+    this.renderToTarget(splatHeight, this.targets.H.write)
+    this.targets.H.swap()
 
-    this.renderer.autoClear = false
-    this.quad.material = material
-    this.renderer.setRenderTarget(target)
-    this.renderer.render(this.scene, this.camera)
-    this.renderer.setRenderTarget(previousTarget)
-    this.renderer.autoClear = previousAutoClear
-  }
+    if (type === 'pigment') {
+      const splatPigment = this.materials.splatPigment
+      splatPigment.uniforms.uSource.value = this.targets.C.read.texture
+      splatPigment.uniforms.uCenter.value.copy(centerVec)
+      splatPigment.uniforms.uRadius.value = radius
+      splatPigment.uniforms.uFlow.value = flow
+      splatPigment.uniforms.uToolType.value = toolType
+      splatPigment.uniforms.uPigment.value.set(color[0], color[1], color[2])
+      this.renderToTarget(splatPigment, this.targets.C.write)
+      this.targets.C.swap()
 
-  // Build the shader materials backing every simulation pass.
-  private createMaterials(): MaterialMap {
-    const centerUniform = () => ({ value: new THREE.Vector2(0, 0) })
-    const pigmentUniform = () => ({ value: new THREE.Vector3(0, 0, 0) })
-
-    const zero = createMaterial(ZERO_FRAGMENT, {})
-
-    const splatHeight = createMaterial(SPLAT_HEIGHT_FRAGMENT, {
-      uSource: { value: null },
-      uCenter: centerUniform(),
-      uRadius: { value: 0 },
-      uFlow: { value: 0 },
-      uToolType: { value: 0 },
-    })
-
-    const splatVelocity = createMaterial(SPLAT_VELOCITY_FRAGMENT, {
-      uSource: { value: null },
-      uCenter: centerUniform(),
-      uRadius: { value: 0 },
-      uFlow: { value: 0 },
-    })
-
-    const splatPigment = createMaterial(SPLAT_PIGMENT_FRAGMENT, {
-      uSource: { value: null },
-      uCenter: centerUniform(),
-      uRadius: { value: 0 },
-      uFlow: { value: 0 },
-      uToolType: { value: 0 },
-      uPigment: pigmentUniform(),
-    })
-
-    const splatBinder = createMaterial(SPLAT_BINDER_FRAGMENT, {
-      uSource: { value: null },
-      uCenter: centerUniform(),
-      uRadius: { value: 0 },
-      uFlow: { value: 0 },
-      uToolType: { value: 0 },
-      uBinderStrength: { value: DEFAULT_BINDER_PARAMS.injection },
-    })
-
-    const advectVelocity = createMaterial(ADVECT_VELOCITY_FRAGMENT, {
-      uHeight: { value: null },
-      uVelocity: { value: null },
-      uDt: { value: DEFAULT_DT },
-      uGrav: { value: 0.9 },
-      uVisc: { value: 0.02 },
-      uTexel: { value: this.texelSize },
-    })
-
-    const advectHeight = createMaterial(ADVECT_HEIGHT_FRAGMENT, {
-      uHeight: { value: null },
-      uVelocity: { value: null },
-      uBinder: { value: null },
-      uDt: { value: DEFAULT_DT },
-      uBinderBuoyancy: { value: DEFAULT_BINDER_PARAMS.buoyancy },
-    })
-
-    const advectPigment = createMaterial(ADVECT_PIGMENT_FRAGMENT, {
-      uPigment: { value: null },
-      uVelocity: { value: null },
-      uDt: { value: DEFAULT_DT },
-    })
-
-    const diffusePigment = createMaterial(PIGMENT_DIFFUSION_FRAGMENT, {
-      uPigment: { value: null },
-      uTexel: { value: this.texelSize },
-      uDiffusion: { value: PIGMENT_DIFFUSION_COEFF },
-      uDt: { value: DEFAULT_DT },
-    })
-
-    const advectBinder = createMaterial(ADVECT_BINDER_FRAGMENT, {
-      uBinder: { value: null },
-      uVelocity: { value: null },
-      uTexel: { value: this.texelSize },
-      uDt: { value: DEFAULT_DT },
-      uDiffusion: { value: DEFAULT_BINDER_PARAMS.diffusion },
-      uDecay: { value: DEFAULT_BINDER_PARAMS.decay },
-    })
-
-    const binderForces = createMaterial(BINDER_FORCE_FRAGMENT, {
-      uVelocity: { value: null },
-      uBinder: { value: null },
-      uTexel: { value: this.texelSize },
-      uDt: { value: DEFAULT_DT },
-      uElasticity: { value: DEFAULT_BINDER_PARAMS.elasticity },
-      uViscosity: { value: DEFAULT_BINDER_PARAMS.viscosity },
-    })
-
-    const absorbUniforms = () => ({
-      uHeight: { value: null },
-      uPigment: { value: null },
-      uWet: { value: null },
-      uDeposits: { value: null },
-      uSettled: { value: null },
-      uAbsorb: { value: 0 },
-      uEvap: { value: 0 },
-      uEdge: { value: 0 },
-      uDepBase: { value: DEPOSITION_BASE },
-      uBeta: { value: DEFAULT_ABSORB_EXPONENT },
-      uAbsorbTime: { value: 0 },
-      uAbsorbTimeOffset: { value: DEFAULT_ABSORB_TIME_OFFSET },
-      uAbsorbFloor: { value: 0 },
-      uHumidity: { value: HUMIDITY_INFLUENCE },
-      uSettle: { value: 0 },
-      uGranStrength: { value: GRANULATION_STRENGTH },
-      uBackrunStrength: { value: 0 },
-      uTexel: { value: this.texelSize },
-    })
-
-    const absorbDeposit = createMaterial(ABSORB_DEPOSIT_FRAGMENT, absorbUniforms())
-    const absorbHeight = createMaterial(ABSORB_HEIGHT_FRAGMENT, absorbUniforms())
-    const absorbPigment = createMaterial(ABSORB_PIGMENT_FRAGMENT, absorbUniforms())
-    const absorbWet = createMaterial(ABSORB_WET_FRAGMENT, absorbUniforms())
-    const absorbSettled = createMaterial(ABSORB_SETTLED_FRAGMENT, absorbUniforms())
-
-    const diffuseWet = createMaterial(PAPER_DIFFUSION_FRAGMENT, {
-      uWet: { value: null },
-      uFiber: { value: this.fiberTexture },
-      uTexel: { value: this.texelSize },
-      uDt: { value: DEFAULT_DT },
-      uReplenish: { value: 0 },
-      uStrength: { value: PAPER_DIFFUSION_STRENGTH },
-    })
-
-    const divergence = createMaterial(PRESSURE_DIVERGENCE_FRAGMENT, {
-      uVelocity: { value: null },
-      uTexel: { value: this.texelSize },
-    })
-
-    const jacobi = createMaterial(PRESSURE_JACOBI_FRAGMENT, {
-      uPressure: { value: null },
-      uDivergence: { value: null },
-      uTexel: { value: this.texelSize },
-    })
-
-    const project = createMaterial(PRESSURE_PROJECT_FRAGMENT, {
-      uVelocity: { value: null },
-      uPressure: { value: null },
-      uTexel: { value: this.texelSize },
-    })
-
-    const composite = createMaterial(COMPOSITE_FRAGMENT, {
-      uDeposits: { value: null },
-      uPaper: { value: PAPER_COLOR.clone() },
-      uK: { value: PIGMENT_K.map((v) => v.clone()) },
-      uS: { value: PIGMENT_S.map((v) => v.clone()) },
-      uLayerScale: { value: KM_LAYER_SCALE },
-    })
-
-    return {
-      zero,
-      splatHeight,
-      splatVelocity,
-      splatPigment,
-      splatBinder,
-      advectVelocity,
-      advectHeight,
-      advectPigment,
-      diffusePigment,
-      advectBinder,
-      binderForces,
-      absorbDeposit,
-      absorbHeight,
-      absorbPigment,
-      absorbWet,
-      absorbSettled,
-      diffuseWet,
-      composite,
-      divergence,
-      jacobi,
-      project,
+      const splatBinder = this.materials.splatBinder
+      splatBinder.uniforms.uSource.value = this.targets.B.read.texture
+      splatBinder.uniforms.uCenter.value.copy(centerVec)
+      splatBinder.uniforms.uRadius.value = radius
+      splatBinder.uniforms.uFlow.value = flow
+      splatBinder.uniforms.uToolType.value = toolType
+      splatBinder.uniforms.uBinderStrength.value = this.binderSettings.injection
+      this.renderToTarget(splatBinder, this.targets.B.write)
+      this.targets.B.swap()
     }
   }
 
-  // Share the same uniform assignments across the different absorb passes.
+  step(params: SimulationParams, dt = DEFAULT_DT) {
+    if (dt <= 0) {
+      return
+    }
+
+    this.binderSettings = { ...params.binder }
+
+    const substeps = this.determineSubsteps(params, dt)
+    const subDt = dt / substeps
+
+    for (let i = 0; i < substeps; i += 1) {
+      this.integrate(subDt, params)
+    }
+
+    this.renderComposite()
+  }
+
+  private integrate(dt: number, params: SimulationParams) {
+    this.simulateFluid(dt, params)
+    this.updateBinder(dt)
+    this.updateHeight(dt)
+    this.updatePigment(dt)
+    this.applyAbsorption(dt, params)
+    this.applyPaperDiffusion(dt, params.absorb * dt)
+  }
+
+  private simulateFluid(dt: number, params: SimulationParams) {
+    const lbmStep = this.materials.lbmStep
+    lbmStep.uniforms.uState0.value = this.fluid.read.texture[0]
+    lbmStep.uniforms.uState1.value = this.fluid.read.texture[1]
+    lbmStep.uniforms.uState2.value = this.fluid.read.texture[2]
+    lbmStep.uniforms.uHeight.value = this.targets.H.read.texture
+    lbmStep.uniforms.uBinder.value = this.targets.B.read.texture
+    lbmStep.uniforms.uDt.value = dt
+    lbmStep.uniforms.uGravity.value = params.grav
+    lbmStep.uniforms.uViscosity.value = params.visc
+    lbmStep.uniforms.uBinderViscosity.value = this.binderSettings.viscosity
+    this.renderToTarget(lbmStep, this.fluid.write)
+    this.fluid.swap()
+
+    const lbmMacro = this.materials.lbmMacro
+    lbmMacro.uniforms.uState0.value = this.fluid.read.texture[0]
+    lbmMacro.uniforms.uState1.value = this.fluid.read.texture[1]
+    lbmMacro.uniforms.uState2.value = this.fluid.read.texture[2]
+    this.renderToTarget(lbmMacro, this.velocityTarget)
+  }
+
+  private updateBinder(dt: number) {
+    const binderUpdate = this.materials.binderUpdate
+    binderUpdate.uniforms.uBinder.value = this.targets.B.read.texture
+    binderUpdate.uniforms.uVelocity.value = this.velocityTarget.texture
+    binderUpdate.uniforms.uDt.value = dt
+    binderUpdate.uniforms.uDiffusion.value = this.binderSettings.diffusion
+    binderUpdate.uniforms.uDecay.value = this.binderSettings.decay
+    this.renderToTarget(binderUpdate, this.targets.B.write)
+    this.targets.B.swap()
+  }
+
+  private updateHeight(dt: number) {
+    const advectHeight = this.materials.advectHeight
+    advectHeight.uniforms.uHeight.value = this.targets.H.read.texture
+    advectHeight.uniforms.uVelocity.value = this.velocityTarget.texture
+    advectHeight.uniforms.uBinder.value = this.targets.B.read.texture
+    advectHeight.uniforms.uBinderBuoyancy.value = this.binderSettings.buoyancy
+    advectHeight.uniforms.uDt.value = dt
+    this.renderToTarget(advectHeight, this.targets.H.write)
+    this.targets.H.swap()
+  }
+
+  private updatePigment(dt: number) {
+    const advectPigment = this.materials.advectPigment
+    advectPigment.uniforms.uPigment.value = this.targets.C.read.texture
+    advectPigment.uniforms.uVelocity.value = this.velocityTarget.texture
+    advectPigment.uniforms.uDt.value = dt
+    this.renderToTarget(advectPigment, this.targets.C.write)
+    this.targets.C.swap()
+
+    const diffusePigment = this.materials.diffusePigment
+    diffusePigment.uniforms.uPigment.value = this.targets.C.read.texture
+    diffusePigment.uniforms.uDiffusion.value = PIGMENT_DIFFUSION_COEFF
+    diffusePigment.uniforms.uDt.value = dt
+    this.renderToTarget(diffusePigment, this.targets.C.write)
+    this.targets.C.swap()
+  }
+
+  private applyAbsorption(dt: number, params: SimulationParams) {
+    const absorbFactor = params.absorb * dt
+    const evapFactor = params.evap * dt
+    const edgeFactor = params.edge * dt
+    const settleFactor = params.granulation ? GRANULATION_SETTLE_RATE * dt : 0
+    const granStrength = params.granulation ? GRANULATION_STRENGTH : 0
+    const beta = params.stateAbsorption ? params.absorbExponent ?? DEFAULT_ABSORB_EXPONENT : 1
+    const humidityInfluence = params.stateAbsorption ? HUMIDITY_INFLUENCE : 0
+    const absorbMin = params.absorbMinFlux ?? DEFAULT_ABSORB_MIN_FLUX
+    const timeOffset = params.absorbTimeOffset ?? DEFAULT_ABSORB_TIME_OFFSET
+
+    const absorbDeposit = this.materials.absorbDeposit
+    this.assignAbsorbUniforms(
+      absorbDeposit,
+      absorbFactor,
+      evapFactor,
+      edgeFactor,
+      settleFactor,
+      beta,
+      humidityInfluence,
+      granStrength,
+      params.backrunStrength,
+      absorbMin,
+      timeOffset,
+    )
+    this.renderToTarget(absorbDeposit, this.targets.DEP.write)
+
+    const absorbHeight = this.materials.absorbHeight
+    this.assignAbsorbUniforms(
+      absorbHeight,
+      absorbFactor,
+      evapFactor,
+      edgeFactor,
+      settleFactor,
+      beta,
+      humidityInfluence,
+      granStrength,
+      params.backrunStrength,
+      absorbMin,
+      timeOffset,
+    )
+    this.renderToTarget(absorbHeight, this.targets.H.write)
+
+    const absorbPigment = this.materials.absorbPigment
+    this.assignAbsorbUniforms(
+      absorbPigment,
+      absorbFactor,
+      evapFactor,
+      edgeFactor,
+      settleFactor,
+      beta,
+      humidityInfluence,
+      granStrength,
+      params.backrunStrength,
+      absorbMin,
+      timeOffset,
+    )
+    this.renderToTarget(absorbPigment, this.targets.C.write)
+
+    const absorbWet = this.materials.absorbWet
+    this.assignAbsorbUniforms(
+      absorbWet,
+      absorbFactor,
+      evapFactor,
+      edgeFactor,
+      settleFactor,
+      beta,
+      humidityInfluence,
+      granStrength,
+      params.backrunStrength,
+      absorbMin,
+      timeOffset,
+    )
+    this.renderToTarget(absorbWet, this.targets.W.write)
+
+    const absorbSettled = this.materials.absorbSettled
+    this.assignAbsorbUniforms(
+      absorbSettled,
+      absorbFactor,
+      evapFactor,
+      edgeFactor,
+      settleFactor,
+      beta,
+      humidityInfluence,
+      granStrength,
+      params.backrunStrength,
+      absorbMin,
+      timeOffset,
+    )
+    this.renderToTarget(absorbSettled, this.targets.S.write)
+
+    this.targets.DEP.swap()
+    this.targets.H.swap()
+    this.targets.C.swap()
+    this.targets.W.swap()
+    this.targets.S.swap()
+  }
+
+  private applyPaperDiffusion(dt: number, replenish: number) {
+    const diffuseWet = this.materials.paperDiffuse
+    diffuseWet.uniforms.uWet.value = this.targets.W.read.texture
+    diffuseWet.uniforms.uFiber.value = this.fiberTexture
+    diffuseWet.uniforms.uStrength.value = PAPER_DIFFUSION_STRENGTH
+    diffuseWet.uniforms.uDt.value = dt
+    diffuseWet.uniforms.uReplenish.value = replenish
+    this.renderToTarget(diffuseWet, this.targets.W.write)
+    this.targets.W.swap()
+  }
+
+  private determineSubsteps(params: SimulationParams, dt: number): number {
+    const maxSubsteps = Math.max(1, Math.floor(params.maxSubsteps))
+    const maxVelocity = this.computeMaxVelocity()
+    if (maxVelocity < EPSILON) {
+      return 1
+    }
+
+    const maxDt = params.cfl / Math.max(maxVelocity * this.size, EPSILON)
+    const needed = Math.ceil(dt / Math.max(maxDt, EPSILON))
+    return Math.max(1, Math.min(maxSubsteps, needed))
+  }
+
+  private computeMaxVelocity(): number {
+    let source: RenderTargetLike = this.velocityTarget
+    const velocityMax = this.materials.velocityMax
+
+    for (let i = 0; i < this.velocityReductionTargets.length; i += 1) {
+      const target = this.velocityReductionTargets[i]
+      const width = source instanceof THREE.WebGLMultipleRenderTargets ? source.width : source.width
+      const height = source instanceof THREE.WebGLMultipleRenderTargets ? source.height : source.height
+      velocityMax.uniforms.uVelocity.value =
+        source instanceof THREE.WebGLMultipleRenderTargets ? source.texture[0] : source.texture
+      velocityMax.uniforms.uTexel.value.set(1 / width, 1 / height)
+      this.renderToTarget(velocityMax, target)
+      source = target
+    }
+
+    const last = this.velocityReductionTargets[this.velocityReductionTargets.length - 1]
+    this.renderer.readRenderTargetPixels(last, 0, 0, 1, 1, this.velocityReadBuffer)
+    return this.velocityReadBuffer[0]
+  }
+
+  private renderComposite() {
+    const composite = this.materials.composite
+    composite.uniforms.uDeposits.value = this.targets.DEP.read.texture
+    this.renderToTarget(composite, this.compositeTarget)
+  }
+
+  private renderToTarget(material: THREE.RawShaderMaterial, target: RenderTargetLike) {
+    const previous = this.renderer.getRenderTarget()
+    this.quad.material = material
+    this.renderer.setRenderTarget(target)
+    this.renderer.render(this.scene, this.camera)
+    this.renderer.setRenderTarget(previous)
+  }
+
   private assignAbsorbUniforms(
     material: THREE.RawShaderMaterial,
     absorb: number,
@@ -1309,134 +459,46 @@ export default class WatercolorSimulation {
     edge: number,
     settle: number,
     beta: number,
-    humidity: number,
-    granStrength: number,
-    backrunStrength: number,
-    absorbTime: number,
+    humidityInfluence: number,
+    granulation: number,
+    backrun: number,
+    absorbMin: number,
     timeOffset: number,
-    absorbFloor: number,
   ) {
-    const uniforms = material.uniforms as Record<string, THREE.IUniform>
-    uniforms.uHeight.value = this.targets.H.read.texture
-    uniforms.uPigment.value = this.targets.C.read.texture
-    uniforms.uWet.value = this.targets.W.read.texture
-    uniforms.uDeposits.value = this.targets.DEP.read.texture
-    if (uniforms.uSettled) uniforms.uSettled.value = this.targets.S.read.texture
-    uniforms.uAbsorb.value = absorb
-    uniforms.uEvap.value = evap
-    uniforms.uEdge.value = edge
-    uniforms.uDepBase.value = DEPOSITION_BASE
-    if (uniforms.uBeta) uniforms.uBeta.value = beta
-    if (uniforms.uHumidity) uniforms.uHumidity.value = humidity
-    if (uniforms.uSettle) uniforms.uSettle.value = settle
-    if (uniforms.uGranStrength) uniforms.uGranStrength.value = granStrength
-    if (uniforms.uBackrunStrength) uniforms.uBackrunStrength.value = backrunStrength
-    if (uniforms.uAbsorbTime) uniforms.uAbsorbTime.value = absorbTime
-    if (uniforms.uAbsorbTimeOffset) uniforms.uAbsorbTimeOffset.value = timeOffset
-    if (uniforms.uAbsorbFloor) uniforms.uAbsorbFloor.value = absorbFloor
+    material.uniforms.uHeight.value = this.targets.H.read.texture
+    material.uniforms.uPigment.value = this.targets.C.read.texture
+    material.uniforms.uWet.value = this.targets.W.read.texture
+    material.uniforms.uDeposits.value = this.targets.DEP.read.texture
+    material.uniforms.uSettled.value = this.targets.S.read.texture
+    material.uniforms.uAbsorb.value = absorb
+    material.uniforms.uEvap.value = evap
+    material.uniforms.uEdge.value = edge
+    material.uniforms.uDepBase.value = DEPOSITION_BASE
+    material.uniforms.uBeta.value = beta
+    material.uniforms.uHumidity.value = humidityInfluence
+    material.uniforms.uSettle.value = settle
+    material.uniforms.uGranStrength.value = granulation
+    material.uniforms.uBackrunStrength.value = backrun
+    material.uniforms.uAbsorbMin.value = absorbMin
+    material.uniforms.uTimeOffset.value = timeOffset
   }
 
-  private createVelocityMaxMaterial(): THREE.RawShaderMaterial {
-    return new THREE.RawShaderMaterial({
-      uniforms: {
-        uVelocity: { value: null },
-        uTexel: { value: this.texelSize.clone() },
-      },
-      vertexShader: FULLSCREEN_VERTEX.trimStart(),
-      fragmentShader: VELOCITY_MAX_FRAGMENT.trimStart(),
-      glslVersion: THREE.GLSL3,
-      depthTest: false,
-      depthWrite: false,
-      blending: THREE.NoBlending,
-    })
-  }
-
-  private createVelocityReductionTargets(size: number): THREE.WebGLRenderTarget[] {
+  private createVelocityReductionTargets(type: THREE.TextureDataType): THREE.WebGLRenderTarget[] {
     const targets: THREE.WebGLRenderTarget[] = []
-    let currentSize = size
-    while (currentSize > 1) {
-      currentSize = Math.max(1, currentSize >> 1)
-      const target = new THREE.WebGLRenderTarget(currentSize, currentSize, {
-        type: THREE.FloatType,
-        format: THREE.RGBAFormat,
-        depthBuffer: false,
-        stencilBuffer: false,
-        magFilter: THREE.NearestFilter,
-        minFilter: THREE.NearestFilter,
-      })
-      target.texture.generateMipmaps = false
-      target.texture.wrapS = THREE.ClampToEdgeWrapping
-      target.texture.wrapT = THREE.ClampToEdgeWrapping
-      target.texture.colorSpace = THREE.NoColorSpace
+    let width = this.size
+    let height = this.size
+    while (width > 1 || height > 1) {
+      width = Math.max(1, Math.floor(width / 2))
+      height = Math.max(1, Math.floor(height / 2))
+      const target = createRenderTarget(width, type)
       targets.push(target)
+      if (width === 1 && height === 1) {
+        break
+      }
+    }
+    if (targets.length === 0) {
+      targets.push(createRenderTarget(1, type))
     }
     return targets
   }
-
-  private computeMaxVelocity(): number {
-    if (this.velocityReductionTargets.length === 0) {
-      return 0
-    }
-
-    let sourceTexture: THREE.Texture = this.targets.UV.read.texture
-    let texelX = this.texelSize.x
-    let texelY = this.texelSize.y
-    const texelUniform = this.velocityMaxMaterial.uniforms.uTexel.value as THREE.Vector2
-
-    for (let i = 0; i < this.velocityReductionTargets.length; i += 1) {
-      const target = this.velocityReductionTargets[i]
-      this.velocityMaxMaterial.uniforms.uVelocity.value = sourceTexture
-      texelUniform.set(texelX, texelY)
-      this.renderToTarget(this.velocityMaxMaterial, target)
-      sourceTexture = target.texture
-      texelX *= 2
-      texelY *= 2
-    }
-
-    const finalTarget = this.velocityReductionTargets[this.velocityReductionTargets.length - 1]
-
-    try {
-      this.renderer.readRenderTargetPixels(finalTarget, 0, 0, 1, 1, this.velocityReadBuffer)
-      return this.velocityReadBuffer[0]
-    } catch {
-      return 0
-    }
-  }
-
-  private determineSubsteps(cfl: number, maxSubsteps: number, dt: number): number {
-    const maxSteps = Math.max(1, Math.floor(maxSubsteps))
-    if (cfl <= 0 || maxSteps <= 1) return 1
-
-    const maxVelocity = this.computeMaxVelocity()
-    if (maxVelocity <= 1e-6) return 1
-
-    const dx = this.texelSize.x
-    const maxDt = (cfl * dx) / maxVelocity
-    if (!Number.isFinite(maxDt) || maxDt <= 0) return 1
-
-    const needed = Math.ceil(dt / maxDt)
-    if (needed <= 1) return 1
-
-    return Math.min(maxSteps, Math.max(1, needed))
-  }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lib/watercolor/constants.ts
+++ b/lib/watercolor/constants.ts
@@ -1,0 +1,47 @@
+import * as THREE from 'three'
+
+import { type BinderParams } from './types'
+
+export const DEFAULT_DT = 1 / 90
+export const KM_LAYER_SCALE = 1.4
+export const PAPER_COLOR = new THREE.Vector3(0.92, 0.91, 0.88)
+export const PIGMENT_DIFFUSION_COEFF = 0.08
+
+export const LBM_BASE_DENSITY = 1.0
+export const LBM_MIN_RELAXATION = 0.52
+
+export const PAPER_DIFFUSION_STRENGTH = 6.0
+export const HUMIDITY_INFLUENCE = 0.6
+export const DEPOSITION_BASE = 0.02
+export const GRANULATION_SETTLE_RATE = 0.28
+export const GRANULATION_STRENGTH = 0.45
+
+export const ABSORPTION_CAPILLARY_RADIUS = 2.6e-4
+export const ABSORPTION_SURFACE_TENSION = 0.0728
+export const ABSORPTION_CONTACT_ANGLE = 0.35
+export const ABSORPTION_MIN_LENGTH = 1e-4
+
+export const DEFAULT_ABSORB_EXPONENT = 0.5
+export const DEFAULT_ABSORB_TIME_OFFSET = 0.15
+export const DEFAULT_ABSORB_MIN_FLUX = 0.02
+
+export const PIGMENT_K = [
+  new THREE.Vector3(1.6, 0.1, 0.1),
+  new THREE.Vector3(0.1, 1.4, 0.15),
+  new THREE.Vector3(0.05, 0.1, 1.2),
+] as const
+
+export const PIGMENT_S = [
+  new THREE.Vector3(0.5, 0.55, 0.6),
+  new THREE.Vector3(0.55, 0.45, 0.5),
+  new THREE.Vector3(0.6, 0.55, 0.35),
+] as const
+
+export const DEFAULT_BINDER_PARAMS: BinderParams = {
+  injection: 0.65,
+  diffusion: 0.12,
+  decay: 0.08,
+  elasticity: 1.25,
+  viscosity: 0.65,
+  buoyancy: 0.12,
+}

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -1,0 +1,206 @@
+import * as THREE from 'three'
+
+import {
+  ABSORB_DEPOSIT_FRAGMENT,
+  ABSORB_HEIGHT_FRAGMENT,
+  ABSORB_PIGMENT_FRAGMENT,
+  ABSORB_SETTLED_FRAGMENT,
+  ABSORB_WET_FRAGMENT,
+  ADVECT_HEIGHT_FRAGMENT,
+  ADVECT_PIGMENT_FRAGMENT,
+  BINDER_UPDATE_FRAGMENT,
+  COMPOSITE_FRAGMENT,
+  FULLSCREEN_VERTEX,
+  LBM_INIT_FRAGMENT,
+  LBM_MACRO_FRAGMENT,
+  LBM_STEP_FRAGMENT,
+  PAPER_DIFFUSION_FRAGMENT,
+  PIGMENT_DIFFUSION_FRAGMENT,
+  SPLAT_BINDER_FRAGMENT,
+  SPLAT_HEIGHT_FRAGMENT,
+  SPLAT_PIGMENT_FRAGMENT,
+  VELOCITY_MAX_FRAGMENT,
+  ZERO_FRAGMENT,
+} from './shaders'
+import {
+  KM_LAYER_SCALE,
+  PAPER_COLOR,
+  PIGMENT_K,
+  PIGMENT_S,
+  LBM_BASE_DENSITY,
+} from './constants'
+import { type MaterialMap } from './types'
+
+const sanitizeShader = (code: string) => code.trimStart()
+
+function createMaterial(fragmentShader: string, uniforms: Record<string, THREE.IUniform>): THREE.RawShaderMaterial {
+  return new THREE.RawShaderMaterial({
+    uniforms,
+    vertexShader: sanitizeShader(FULLSCREEN_VERTEX),
+    fragmentShader: sanitizeShader(fragmentShader),
+    glslVersion: THREE.GLSL3,
+    depthTest: false,
+    depthWrite: false,
+    blending: THREE.NoBlending,
+  })
+}
+
+export function createMaterials(size: number): MaterialMap {
+  const texel = new THREE.Vector2(1 / size, 1 / size)
+
+  const zero = createMaterial(ZERO_FRAGMENT, {})
+
+  const splatHeight = createMaterial(SPLAT_HEIGHT_FRAGMENT, {
+    uSource: { value: null },
+    uCenter: { value: new THREE.Vector2() },
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uToolType: { value: 0 },
+  })
+
+  const splatPigment = createMaterial(SPLAT_PIGMENT_FRAGMENT, {
+    uSource: { value: null },
+    uCenter: { value: new THREE.Vector2() },
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uToolType: { value: 0 },
+    uPigment: { value: new THREE.Vector3() },
+  })
+
+  const splatBinder = createMaterial(SPLAT_BINDER_FRAGMENT, {
+    uSource: { value: null },
+    uCenter: { value: new THREE.Vector2() },
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uToolType: { value: 0 },
+    uBinderStrength: { value: 0 },
+  })
+
+  const lbmInit = createMaterial(LBM_INIT_FRAGMENT, {
+    uBaseDensity: { value: LBM_BASE_DENSITY },
+  })
+  lbmInit.extensions = { drawBuffers: true }
+
+  const lbmStep = createMaterial(LBM_STEP_FRAGMENT, {
+    uState0: { value: null },
+    uState1: { value: null },
+    uState2: { value: null },
+    uHeight: { value: null },
+    uBinder: { value: null },
+    uTexel: { value: texel.clone() },
+    uDt: { value: 0 },
+    uGravity: { value: 0 },
+    uViscosity: { value: 0 },
+    uBinderViscosity: { value: 0 },
+    uBaseDensity: { value: LBM_BASE_DENSITY },
+  })
+  lbmStep.extensions = { drawBuffers: true }
+
+  const lbmMacro = createMaterial(LBM_MACRO_FRAGMENT, {
+    uState0: { value: null },
+    uState1: { value: null },
+    uState2: { value: null },
+    uBaseDensity: { value: LBM_BASE_DENSITY },
+  })
+  lbmMacro.extensions = { drawBuffers: true }
+
+  const advectHeight = createMaterial(ADVECT_HEIGHT_FRAGMENT, {
+    uHeight: { value: null },
+    uVelocity: { value: null },
+    uBinder: { value: null },
+    uDt: { value: 0 },
+    uBinderBuoyancy: { value: 0 },
+  })
+
+  const advectPigment = createMaterial(ADVECT_PIGMENT_FRAGMENT, {
+    uPigment: { value: null },
+    uVelocity: { value: null },
+    uDt: { value: 0 },
+  })
+
+  const diffusePigment = createMaterial(PIGMENT_DIFFUSION_FRAGMENT, {
+    uPigment: { value: null },
+    uTexel: { value: texel.clone() },
+    uDiffusion: { value: 0 },
+    uDt: { value: 0 },
+  })
+
+  const binderUpdate = createMaterial(BINDER_UPDATE_FRAGMENT, {
+    uBinder: { value: null },
+    uVelocity: { value: null },
+    uTexel: { value: texel.clone() },
+    uDt: { value: 0 },
+    uDiffusion: { value: 0 },
+    uDecay: { value: 0 },
+  })
+
+  const absorbUniforms = {
+    uHeight: { value: null as THREE.Texture | null },
+    uPigment: { value: null as THREE.Texture | null },
+    uWet: { value: null as THREE.Texture | null },
+    uDeposits: { value: null as THREE.Texture | null },
+    uSettled: { value: null as THREE.Texture | null },
+    uAbsorb: { value: 0 },
+    uEvap: { value: 0 },
+    uEdge: { value: 0 },
+    uDepBase: { value: 0 },
+    uBeta: { value: 1 },
+    uHumidity: { value: 0 },
+    uSettle: { value: 0 },
+    uGranStrength: { value: 0 },
+    uBackrunStrength: { value: 0 },
+    uAbsorbMin: { value: 0 },
+    uTimeOffset: { value: 0 },
+    uTexel: { value: texel.clone() },
+  }
+
+  const absorbDeposit = createMaterial(ABSORB_DEPOSIT_FRAGMENT, { ...absorbUniforms })
+  const absorbHeight = createMaterial(ABSORB_HEIGHT_FRAGMENT, { ...absorbUniforms })
+  const absorbPigment = createMaterial(ABSORB_PIGMENT_FRAGMENT, { ...absorbUniforms })
+  const absorbWet = createMaterial(ABSORB_WET_FRAGMENT, { ...absorbUniforms })
+  const absorbSettled = createMaterial(ABSORB_SETTLED_FRAGMENT, { ...absorbUniforms })
+
+  const paperDiffuse = createMaterial(PAPER_DIFFUSION_FRAGMENT, {
+    uWet: { value: null },
+    uFiber: { value: null },
+    uStrength: { value: 0 },
+    uDt: { value: 0 },
+    uReplenish: { value: 0 },
+    uTexel: { value: texel.clone() },
+  })
+
+  const velocityMax = createMaterial(VELOCITY_MAX_FRAGMENT, {
+    uVelocity: { value: null },
+    uTexel: { value: texel.clone() },
+  })
+
+  const composite = createMaterial(COMPOSITE_FRAGMENT, {
+    uDeposits: { value: null },
+    uPaper: { value: PAPER_COLOR.clone() },
+    uK: { value: PIGMENT_K.map((v) => v.clone()) },
+    uS: { value: PIGMENT_S.map((v) => v.clone()) },
+    uLayerScale: { value: KM_LAYER_SCALE },
+  })
+
+  return {
+    zero,
+    composite,
+    splatHeight,
+    splatPigment,
+    splatBinder,
+    lbmInit,
+    lbmStep,
+    lbmMacro,
+    advectHeight,
+    advectPigment,
+    diffusePigment,
+    binderUpdate,
+    absorbDeposit,
+    absorbHeight,
+    absorbPigment,
+    absorbWet,
+    absorbSettled,
+    paperDiffuse,
+    velocityMax,
+  }
+}

--- a/lib/watercolor/shaders.ts
+++ b/lib/watercolor/shaders.ts
@@ -1,0 +1,571 @@
+export const FULLSCREEN_VERTEX = `
+in vec3 position;
+in vec2 uv;
+out vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position.xy, 0.0, 1.0);
+}
+`
+
+export const ZERO_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+  fragColor = vec4(0.0);
+}
+`
+
+export const SPLAT_COMMON = `
+precision highp float;
+in vec2 vUv;
+uniform sampler2D uSource;
+uniform vec2 uCenter;
+uniform float uRadius;
+uniform float uFlow;
+
+float splatFalloff(vec2 uv, float radius) {
+  vec2 delta = uv - uCenter;
+  float r = max(radius, 1e-6);
+  return exp(-9.0 * dot(delta, delta) / (r * r + 1e-6));
+}
+`
+
+export const SPLAT_HEIGHT_FRAGMENT = `
+${SPLAT_COMMON}
+out vec4 fragColor;
+uniform float uToolType;
+void main() {
+  vec4 src = texture(uSource, vUv);
+  float fall = splatFalloff(vUv, uRadius);
+  float waterMul = mix(1.0, 0.7, step(0.5, uToolType));
+  src.r += waterMul * uFlow * fall;
+  fragColor = vec4(src.r, 0.0, 0.0, 1.0);
+}
+`
+
+export const SPLAT_PIGMENT_FRAGMENT = `
+${SPLAT_COMMON}
+out vec4 fragColor;
+uniform float uToolType;
+uniform vec3 uPigment;
+void main() {
+  vec4 src = texture(uSource, vUv);
+  float fall = splatFalloff(vUv, uRadius);
+  float pigmentMask = step(0.5, uToolType);
+  vec3 add = uPigment * (uFlow * fall * pigmentMask);
+  fragColor = vec4(src.rgb + add, src.a);
+}
+`
+
+export const SPLAT_BINDER_FRAGMENT = `
+${SPLAT_COMMON}
+out vec4 fragColor;
+uniform float uToolType;
+uniform float uBinderStrength;
+void main() {
+  vec4 src = texture(uSource, vUv);
+  float fall = splatFalloff(vUv, uRadius);
+  float mask = step(0.5, uToolType);
+  float add = uBinderStrength * uFlow * fall * mask;
+  fragColor = vec4(src.r + add, 0.0, 0.0, 1.0);
+}
+`
+
+export const LBM_INIT_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+layout(location = 0) out vec4 frag0;
+layout(location = 1) out vec4 frag1;
+layout(location = 2) out vec4 frag2;
+uniform float uBaseDensity;
+const float W0 = 4.0 / 9.0;
+const float W1 = 1.0 / 9.0;
+const float W2 = 1.0 / 36.0;
+void main() {
+  float rho = uBaseDensity;
+  frag0 = vec4(W0 * rho, W1 * rho, W1 * rho, W1 * rho);
+  frag1 = vec4(W1 * rho, W2 * rho, W2 * rho, W2 * rho);
+  frag2 = vec4(W2 * rho, 0.0, 0.0, 0.0);
+}
+`
+
+export const LBM_STEP_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+layout(location = 0) out vec4 frag0;
+layout(location = 1) out vec4 frag1;
+layout(location = 2) out vec4 frag2;
+uniform sampler2D uState0;
+uniform sampler2D uState1;
+uniform sampler2D uState2;
+uniform sampler2D uHeight;
+uniform sampler2D uBinder;
+uniform vec2 uTexel;
+uniform float uDt;
+uniform float uGravity;
+uniform float uViscosity;
+uniform float uBinderViscosity;
+uniform float uBaseDensity;
+
+const float W0 = 4.0 / 9.0;
+const float W1 = 1.0 / 9.0;
+const float W2 = 1.0 / 36.0;
+
+vec2 clampUv(vec2 uv, vec2 texel) {
+  return clamp(uv, texel * 0.5, vec2(1.0) - texel * 0.5);
+}
+
+float sampleDir(int dir, vec2 coord) {
+  if (dir == 0) {
+    return texture(uState0, coord).x;
+  }
+  if (dir == 1) {
+    return texture(uState0, coord).y;
+  }
+  if (dir == 2) {
+    return texture(uState0, coord).z;
+  }
+  if (dir == 3) {
+    return texture(uState0, coord).w;
+  }
+  if (dir == 4) {
+    return texture(uState1, coord).x;
+  }
+  if (dir == 5) {
+    return texture(uState1, coord).y;
+  }
+  if (dir == 6) {
+    return texture(uState1, coord).z;
+  }
+  if (dir == 7) {
+    return texture(uState1, coord).w;
+  }
+  return texture(uState2, coord).x;
+}
+
+void main() {
+  vec2 texel = uTexel;
+  float f0 = sampleDir(0, vUv);
+  float f1 = sampleDir(1, clampUv(vUv - vec2(texel.x, 0.0), texel));
+  float f2 = sampleDir(2, clampUv(vUv - vec2(0.0, texel.y), texel));
+  float f3 = sampleDir(3, clampUv(vUv + vec2(texel.x, 0.0), texel));
+  float f4 = sampleDir(4, clampUv(vUv + vec2(0.0, texel.y), texel));
+  float f5 = sampleDir(5, clampUv(vUv - vec2(texel.x, texel.y), texel));
+  float f6 = sampleDir(6, clampUv(vUv + vec2(texel.x, -texel.y), texel));
+  float f7 = sampleDir(7, clampUv(vUv + vec2(texel.x, texel.y), texel));
+  float f8 = sampleDir(8, clampUv(vUv - vec2(texel.x, -texel.y), texel));
+
+  float rho = f0 + f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8;
+  vec2 mom = vec2(
+    (f1 - f3) + (f5 - f6) + (f8 - f7),
+    (f2 - f4) + (f5 + f6) - (f7 + f8)
+  );
+  vec2 vel = mom / max(rho, 1e-5);
+
+  float h = texture(uHeight, vUv).r;
+  float hL = texture(uHeight, clampUv(vUv - vec2(texel.x, 0.0), texel)).r;
+  float hR = texture(uHeight, clampUv(vUv + vec2(texel.x, 0.0), texel)).r;
+  float hB = texture(uHeight, clampUv(vUv - vec2(0.0, texel.y), texel)).r;
+  float hT = texture(uHeight, clampUv(vUv + vec2(0.0, texel.y), texel)).r;
+  vec2 gradH = vec2((hR - hL) * 0.5, (hT - hB) * 0.5);
+  vec2 force = -uGravity * gradH;
+  vel += uDt * force;
+
+  float binder = texture(uBinder, vUv).r;
+  float nu = max(uViscosity + uBinderViscosity * binder, 1e-4);
+  float tau = max(3.0 * nu + 0.5, 0.52);
+  float omega = 1.0 / tau;
+
+  float rhoTarget = max(uBaseDensity + h, 1e-5);
+  float u2 = dot(vel, vel);
+
+  float cu1 = 3.0 * vel.x;
+  float cu2 = 3.0 * vel.y;
+  float cu3 = -cu1;
+  float cu4 = -cu2;
+  float cu5 = 3.0 * dot(vel, vec2(1.0, 1.0));
+  float cu6 = 3.0 * dot(vel, vec2(-1.0, 1.0));
+  float cu7 = 3.0 * dot(vel, vec2(-1.0, -1.0));
+  float cu8 = 3.0 * dot(vel, vec2(1.0, -1.0));
+
+  float feq0 = W0 * rhoTarget * (1.0 - 1.5 * u2);
+  float feq1 = W1 * rhoTarget * (1.0 + cu1 + 0.5 * cu1 * cu1 - 1.5 * u2);
+  float feq2 = W1 * rhoTarget * (1.0 + cu2 + 0.5 * cu2 * cu2 - 1.5 * u2);
+  float feq3 = W1 * rhoTarget * (1.0 + cu3 + 0.5 * cu3 * cu3 - 1.5 * u2);
+  float feq4 = W1 * rhoTarget * (1.0 + cu4 + 0.5 * cu4 * cu4 - 1.5 * u2);
+  float feq5 = W2 * rhoTarget * (1.0 + cu5 + 0.5 * cu5 * cu5 - 1.5 * u2);
+  float feq6 = W2 * rhoTarget * (1.0 + cu6 + 0.5 * cu6 * cu6 - 1.5 * u2);
+  float feq7 = W2 * rhoTarget * (1.0 + cu7 + 0.5 * cu7 * cu7 - 1.5 * u2);
+  float feq8 = W2 * rhoTarget * (1.0 + cu8 + 0.5 * cu8 * cu8 - 1.5 * u2);
+
+  float nf0 = f0 + omega * (feq0 - f0);
+  float nf1 = f1 + omega * (feq1 - f1);
+  float nf2 = f2 + omega * (feq2 - f2);
+  float nf3 = f3 + omega * (feq3 - f3);
+  float nf4 = f4 + omega * (feq4 - f4);
+  float nf5 = f5 + omega * (feq5 - f5);
+  float nf6 = f6 + omega * (feq6 - f6);
+  float nf7 = f7 + omega * (feq7 - f7);
+  float nf8 = f8 + omega * (feq8 - f8);
+
+  frag0 = vec4(nf0, nf1, nf2, nf3);
+  frag1 = vec4(nf4, nf5, nf6, nf7);
+  frag2 = vec4(nf8, 0.0, 0.0, 0.0);
+}
+`
+
+export const LBM_MACRO_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+layout(location = 0) out vec4 fragColor;
+uniform sampler2D uState0;
+uniform sampler2D uState1;
+uniform sampler2D uState2;
+uniform float uBaseDensity;
+void main() {
+  vec4 s0 = texture(uState0, vUv);
+  vec4 s1 = texture(uState1, vUv);
+  vec4 s2 = texture(uState2, vUv);
+  float f0 = s0.x;
+  float f1 = s0.y;
+  float f2 = s0.z;
+  float f3 = s0.w;
+  float f4 = s1.x;
+  float f5 = s1.y;
+  float f6 = s1.z;
+  float f7 = s1.w;
+  float f8 = s2.x;
+  float rho = f0 + f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8;
+  vec2 mom = vec2(
+    (f1 - f3) + (f5 - f6) + (f8 - f7),
+    (f2 - f4) + (f5 + f6) - (f7 + f8)
+  );
+  vec2 vel = mom / max(rho, 1e-5);
+  float height = max(rho - uBaseDensity, 0.0);
+  fragColor = vec4(vel, height, 1.0);
+}
+`
+
+export const ADVECT_HEIGHT_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uHeight;
+uniform sampler2D uVelocity;
+uniform sampler2D uBinder;
+uniform float uDt;
+uniform float uBinderBuoyancy;
+void main() {
+  vec2 vel = texture(uVelocity, vUv).xy;
+  vec2 back = vUv - uDt * vel;
+  vec4 sampleColor = texture(uHeight, back);
+  float binder = texture(uBinder, vUv).r;
+  float newH = max(sampleColor.r + uBinderBuoyancy * binder * uDt, 0.0);
+  fragColor = vec4(newH, 0.0, 0.0, 1.0);
+}
+`
+
+export const ADVECT_PIGMENT_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uPigment;
+uniform sampler2D uVelocity;
+uniform float uDt;
+void main() {
+  vec2 vel = texture(uVelocity, vUv).xy;
+  vec2 back = vUv - uDt * vel;
+  vec4 sampleColor = texture(uPigment, back);
+  fragColor = vec4(max(sampleColor.rgb, vec3(0.0)), sampleColor.a);
+}
+`
+
+export const PIGMENT_DIFFUSION_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uPigment;
+uniform vec2 uTexel;
+uniform float uDiffusion;
+uniform float uDt;
+
+vec3 sampleRGB(vec2 uv) {
+  return texture(uPigment, uv).rgb;
+}
+
+void main() {
+  vec4 center = texture(uPigment, vUv);
+  vec2 du = vec2(uTexel.x, 0.0);
+  vec2 dv = vec2(0.0, uTexel.y);
+  vec3 left = sampleRGB(vUv - du);
+  vec3 right = sampleRGB(vUv + du);
+  vec3 bottom = sampleRGB(vUv - dv);
+  vec3 top = sampleRGB(vUv + dv);
+  vec3 laplacian = left + right + top + bottom - 4.0 * center.rgb;
+  vec3 diffused = center.rgb + uDiffusion * laplacian * uDt;
+  fragColor = vec4(max(diffused, vec3(0.0)), center.a);
+}
+`
+
+export const BINDER_UPDATE_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uBinder;
+uniform sampler2D uVelocity;
+uniform vec2 uTexel;
+uniform float uDt;
+uniform float uDiffusion;
+uniform float uDecay;
+
+float sampleBinder(vec2 coord) {
+  return texture(uBinder, coord).r;
+}
+
+void main() {
+  vec2 vel = texture(uVelocity, vUv).xy;
+  vec2 back = vUv - uDt * vel;
+  float binder = texture(uBinder, back).r;
+  float left = sampleBinder(vUv - vec2(uTexel.x, 0.0));
+  float right = sampleBinder(vUv + vec2(uTexel.x, 0.0));
+  float bottom = sampleBinder(vUv - vec2(0.0, uTexel.y));
+  float top = sampleBinder(vUv + vec2(0.0, uTexel.y));
+  float lap = left + right + top + bottom - 4.0 * binder;
+  binder += uDiffusion * lap * uDt;
+  binder = max(binder - uDecay * uDt, 0.0);
+  fragColor = vec4(binder, 0.0, 0.0, 1.0);
+}
+`
+
+export const ABSORB_COMMON = `
+precision highp float;
+in vec2 vUv;
+uniform sampler2D uHeight;
+uniform sampler2D uPigment;
+uniform sampler2D uWet;
+uniform sampler2D uDeposits;
+uniform sampler2D uSettled;
+uniform float uAbsorb;
+uniform float uEvap;
+uniform float uEdge;
+uniform float uDepBase;
+uniform float uBeta;
+uniform float uHumidity;
+uniform float uSettle;
+uniform float uGranStrength;
+uniform float uBackrunStrength;
+uniform float uAbsorbMin;
+uniform float uTimeOffset;
+uniform vec2 uTexel;
+
+struct AbsorbResult {
+  float newH;
+  float newWet;
+  vec3 pigment;
+  vec3 dep;
+  vec3 settled;
+};
+
+AbsorbResult computeAbsorb(vec2 uv) {
+  AbsorbResult res;
+  float h = texture(uHeight, uv).r;
+  vec3 pigment = texture(uPigment, uv).rgb;
+  float wet = texture(uWet, uv).r;
+  vec3 dep = texture(uDeposits, uv).rgb;
+  vec3 settled = texture(uSettled, uv).rgb;
+
+  vec2 du = vec2(uTexel.x, 0.0);
+  vec2 dv = vec2(0.0, uTexel.y);
+  float hx = texture(uHeight, uv + du).r - texture(uHeight, uv - du).r;
+  float hy = texture(uHeight, uv + dv).r - texture(uHeight, uv - dv).r;
+  float edgeBias = uEdge * 0.5 * sqrt(hx * hx + hy * hy);
+
+  float wL = texture(uWet, uv - du).r;
+  float wR = texture(uWet, uv + du).r;
+  float wB = texture(uWet, uv - dv).r;
+  float wT = texture(uWet, uv + dv).r;
+  float outwardDiff = max(wet - wL, 0.0) + max(wet - wR, 0.0) + max(wet - wB, 0.0) + max(wet - wT, 0.0);
+  float edgeAdvance = max(outwardDiff * 0.25 - 0.05, 0.0);
+  float bloomFactor = clamp(uBackrunStrength * edgeAdvance, 0.0, 1.0) * step(1e-5, h);
+
+  float humidity = clamp(1.0 - wet, 0.0, 1.0);
+  float timeFactor = uTimeOffset > 0.0 ? inversesqrt(max(uTimeOffset + wet, 1e-3)) : 1.0;
+  float absorbCandidate = uAbsorb * pow(humidity, uBeta) * timeFactor;
+  float absorbRate = max(uAbsorbMin, absorbCandidate);
+  float evapBase = uEvap * sqrt(max(h, 0.0));
+  float evapRate = evapBase * mix(1.0, humidity, uHumidity);
+  float totalOut = absorbRate + evapRate;
+
+  float newH = max(h - totalOut, 0.0);
+  float remRaw = totalOut / max(h, 1e-6);
+  if (h <= 1e-6) {
+    remRaw = 1.0;
+  }
+  float remFrac = clamp(min(1.0, remRaw), 0.0, 1.0);
+  float depFrac = clamp(remFrac * (0.5 + edgeBias) + uDepBase * edgeBias, 0.0, 1.0);
+  vec3 depAdd = pigment * depFrac;
+  dep += depAdd;
+  pigment = max(pigment - depAdd, vec3(0.0));
+
+  vec3 bloomDep = pigment * bloomFactor;
+  dep += bloomDep;
+  pigment = max(pigment - bloomDep, vec3(0.0));
+
+  float settleRate = clamp(uSettle, 0.0, 1.0);
+  vec3 settleAdd = pigment * settleRate;
+  pigment = max(pigment - settleAdd, vec3(0.0));
+  vec3 settledNew = settled + settleAdd;
+
+  float granCoeff = clamp(uGranStrength * edgeBias, 0.0, 1.0);
+  vec3 granSource = pigment + settledNew;
+  vec3 granDep = granSource * granCoeff;
+  vec3 totalSource = max(granSource, vec3(1e-5));
+  vec3 fromPigment = granDep * (pigment / totalSource);
+  vec3 fromSettled = granDep * (settledNew / totalSource);
+  pigment = max(pigment - fromPigment, vec3(0.0));
+  settledNew = max(settledNew - fromSettled, vec3(0.0));
+  dep += granDep;
+
+  float newWet = clamp(wet + absorbRate, 0.0, 1.0);
+
+  res.newH = newH;
+  res.newWet = newWet;
+  res.pigment = pigment;
+  res.dep = dep;
+  res.settled = settledNew;
+  return res;
+}
+`
+
+export const ABSORB_DEPOSIT_FRAGMENT = `
+${ABSORB_COMMON}
+out vec4 fragColor;
+void main() {
+  AbsorbResult res = computeAbsorb(vUv);
+  fragColor = vec4(res.dep, 1.0);
+}
+`
+
+export const ABSORB_HEIGHT_FRAGMENT = `
+${ABSORB_COMMON}
+out vec4 fragColor;
+void main() {
+  AbsorbResult res = computeAbsorb(vUv);
+  fragColor = vec4(res.newH, 0.0, 0.0, 1.0);
+}
+`
+
+export const ABSORB_PIGMENT_FRAGMENT = `
+${ABSORB_COMMON}
+out vec4 fragColor;
+void main() {
+  AbsorbResult res = computeAbsorb(vUv);
+  fragColor = vec4(res.pigment, 1.0);
+}
+`
+
+export const ABSORB_WET_FRAGMENT = `
+${ABSORB_COMMON}
+out vec4 fragColor;
+void main() {
+  AbsorbResult res = computeAbsorb(vUv);
+  fragColor = vec4(res.newWet, 0.0, 0.0, 1.0);
+}
+`
+
+export const ABSORB_SETTLED_FRAGMENT = `
+${ABSORB_COMMON}
+out vec4 fragColor;
+void main() {
+  AbsorbResult res = computeAbsorb(vUv);
+  fragColor = vec4(res.settled, 1.0);
+}
+`
+
+export const PAPER_DIFFUSION_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uWet;
+uniform sampler2D uFiber;
+uniform float uStrength;
+uniform float uDt;
+uniform float uReplenish;
+uniform vec2 uTexel;
+void main() {
+  vec4 fiber = texture(uFiber, vUv);
+  vec2 dir = normalize(fiber.xy * 2.0 - 1.0);
+  vec2 dirTex = dir * uTexel;
+  vec2 perp = vec2(-dir.y, dir.x);
+  vec2 perpTex = perp * uTexel;
+
+  float w = texture(uWet, vUv).r;
+  float wParaPlus = texture(uWet, vUv + dirTex).r;
+  float wParaMinus = texture(uWet, vUv - dirTex).r;
+  float wPerpPlus = texture(uWet, vUv + perpTex).r;
+  float wPerpMinus = texture(uWet, vUv - perpTex).r;
+
+  float dPara = fiber.z;
+  float dPerp = fiber.w;
+  float lap = dPara * (wParaPlus - 2.0 * w + wParaMinus) + dPerp * (wPerpPlus - 2.0 * w + wPerpMinus);
+  float diffusion = uStrength * lap;
+  float replenish = uReplenish * (1.0 - w);
+  float newW = clamp(w + uDt * (diffusion + replenish), 0.0, 1.0);
+  fragColor = vec4(newW, 0.0, 0.0, 1.0);
+}
+`
+
+export const VELOCITY_MAX_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uVelocity;
+uniform vec2 uTexel;
+
+float velocityMag(vec2 coord) {
+  vec2 vel = texture(uVelocity, coord).xy;
+  return length(vel);
+}
+
+void main() {
+  vec2 halfStep = 0.5 * uTexel;
+  float m = velocityMag(vUv);
+  m = max(m, velocityMag(vUv + vec2(-halfStep.x, -halfStep.y)));
+  m = max(m, velocityMag(vUv + vec2(halfStep.x, -halfStep.y)));
+  m = max(m, velocityMag(vUv + vec2(-halfStep.x, halfStep.y)));
+  m = max(m, velocityMag(vUv + vec2(halfStep.x, halfStep.y)));
+  fragColor = vec4(m, 0.0, 0.0, 1.0);
+}
+`
+
+export const COMPOSITE_FRAGMENT = `
+precision highp float;
+in vec2 vUv;
+out vec4 fragColor;
+uniform sampler2D uDeposits;
+uniform vec3 uPaper;
+uniform vec3 uK[3];
+uniform vec3 uS[3];
+uniform float uLayerScale;
+
+vec3 infiniteLayer(vec3 K, vec3 S) {
+  vec3 safeS = max(S, vec3(1e-3));
+  vec3 r = 1.0 + K / safeS;
+  vec3 disc = max(r * r - vec3(1.0), vec3(0.0));
+  return clamp(r - sqrt(disc), vec3(0.0), vec3(1.0));
+}
+
+void main() {
+  vec3 dep = texture(uDeposits, vUv).rgb;
+  vec3 K = dep.r * uK[0] + dep.g * uK[1] + dep.b * uK[2];
+  vec3 S = vec3(0.4) + dep.r * uS[0] + dep.g * uS[1] + dep.b * uS[2];
+  float density = dot(dep, vec3(1.0));
+  float layerK = 1.0 + uLayerScale * density;
+  float layerS = 1.0 + 0.5 * uLayerScale * density;
+  vec3 R = infiniteLayer(K * layerK, S * layerS);
+  vec3 col = clamp(R * uPaper, vec3(0.0), vec3(1.0));
+  fragColor = vec4(col, 1.0);
+}
+`

--- a/lib/watercolor/targets.ts
+++ b/lib/watercolor/targets.ts
@@ -1,0 +1,76 @@
+import * as THREE from 'three'
+
+function configureTexture(texture: THREE.Texture) {
+  texture.generateMipmaps = false
+  texture.wrapS = THREE.ClampToEdgeWrapping
+  texture.wrapT = THREE.ClampToEdgeWrapping
+  texture.magFilter = THREE.LinearFilter
+  texture.minFilter = THREE.LinearFilter
+  texture.colorSpace = THREE.NoColorSpace
+}
+
+export function createRenderTarget(size: number, type: THREE.TextureDataType) {
+  const target = new THREE.WebGLRenderTarget(size, size, {
+    type,
+    format: THREE.RGBAFormat,
+    depthBuffer: false,
+    stencilBuffer: false,
+    magFilter: THREE.LinearFilter,
+    minFilter: THREE.LinearFilter,
+  })
+  configureTexture(target.texture)
+  return target
+}
+
+export interface PingPongTarget<T extends THREE.WebGLRenderTarget> {
+  read: T
+  write: T
+  swap: () => void
+}
+
+export function createPingPong(size: number, type: THREE.TextureDataType): PingPongTarget<THREE.WebGLRenderTarget> {
+  const a = createRenderTarget(size, type)
+  const b = createRenderTarget(size, type)
+  return {
+    read: a,
+    write: b,
+    swap() {
+      const temp = this.read
+      this.read = this.write
+      this.write = temp
+    },
+  }
+}
+
+export function createMultipleRenderTarget(
+  size: number,
+  type: THREE.TextureDataType,
+  count: number,
+): THREE.WebGLMultipleRenderTargets {
+  const target = new THREE.WebGLMultipleRenderTargets(size, size, count, {
+    type,
+    format: THREE.RGBAFormat,
+    depthBuffer: false,
+    stencilBuffer: false,
+    magFilter: THREE.LinearFilter,
+    minFilter: THREE.LinearFilter,
+  })
+  for (let i = 0; i < count; i += 1) {
+    configureTexture(target.texture[i])
+  }
+  return target
+}
+
+export function createLBMPingPong(size: number, type: THREE.TextureDataType): PingPongTarget<THREE.WebGLMultipleRenderTargets> {
+  const a = createMultipleRenderTarget(size, type, 3)
+  const b = createMultipleRenderTarget(size, type, 3)
+  return {
+    read: a,
+    write: b,
+    swap() {
+      const temp = this.read
+      this.read = this.write
+      this.write = temp
+    },
+  }
+}

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -1,0 +1,69 @@
+import * as THREE from 'three'
+
+export type BrushType = 'water' | 'pigment'
+
+export interface BrushSettings {
+  center: [number, number]
+  radius: number
+  flow: number
+  type: BrushType
+  color: [number, number, number]
+}
+
+export interface BinderParams {
+  injection: number
+  diffusion: number
+  decay: number
+  elasticity: number
+  viscosity: number
+  buoyancy: number
+}
+
+export interface ReservoirParams {
+  waterCapacityWater: number
+  waterCapacityPigment: number
+  pigmentCapacity: number
+  waterConsumption: number
+  pigmentConsumption: number
+  stampSpacing: number
+}
+
+export interface SimulationParams {
+  grav: number
+  visc: number
+  absorb: number
+  evap: number
+  edge: number
+  stateAbsorption: boolean
+  granulation: boolean
+  backrunStrength: number
+  absorbExponent: number
+  absorbTimeOffset: number
+  absorbMinFlux: number
+  cfl: number
+  maxSubsteps: number
+  binder: BinderParams
+  reservoir: ReservoirParams
+}
+
+export interface MaterialMap {
+  zero: THREE.RawShaderMaterial
+  composite: THREE.RawShaderMaterial
+  splatHeight: THREE.RawShaderMaterial
+  splatPigment: THREE.RawShaderMaterial
+  splatBinder: THREE.RawShaderMaterial
+  lbmInit: THREE.RawShaderMaterial
+  lbmStep: THREE.RawShaderMaterial
+  lbmMacro: THREE.RawShaderMaterial
+  advectHeight: THREE.RawShaderMaterial
+  advectPigment: THREE.RawShaderMaterial
+  diffusePigment: THREE.RawShaderMaterial
+  binderUpdate: THREE.RawShaderMaterial
+  absorbDeposit: THREE.RawShaderMaterial
+  absorbHeight: THREE.RawShaderMaterial
+  absorbPigment: THREE.RawShaderMaterial
+  absorbWet: THREE.RawShaderMaterial
+  absorbSettled: THREE.RawShaderMaterial
+  paperDiffuse: THREE.RawShaderMaterial
+  velocityMax: THREE.RawShaderMaterial
+}


### PR DESCRIPTION
## Summary
- replace the SPH particle integrator with a GPU D2Q9 lattice Boltzmann velocity solver and keep scalar fields on ping-pong render targets
- add LBM collision/stream shaders, binder/pigment advection passes, and updated absorption uniforms while wiring new materials and targets
- refresh the overview guide to describe the LBM workflow, texture state, and revised Lucas–Washburn controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3b0b85788326a545e6fe9349567d