### PR TITLE
Stabilize LBM forcing near dry texels

### DIFF
--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -55,18 +55,19 @@ export type PingPongTarget = SwapTarget & {
   swap: () => void
 }
 
+export type MaterialTriplet = [
+  THREE.RawShaderMaterial,
+  THREE.RawShaderMaterial,
+  THREE.RawShaderMaterial,
+]
+
 export type MaterialMap = {
   zero: THREE.RawShaderMaterial
-  splatHeight: THREE.RawShaderMaterial
-  splatVelocity: THREE.RawShaderMaterial
   splatPigment: THREE.RawShaderMaterial
   splatBinder: THREE.RawShaderMaterial
-  advectVelocity: THREE.RawShaderMaterial
-  advectHeight: THREE.RawShaderMaterial
   advectPigment: THREE.RawShaderMaterial
   diffusePigment: THREE.RawShaderMaterial
   advectBinder: THREE.RawShaderMaterial
-  binderForces: THREE.RawShaderMaterial
   absorbDeposit: THREE.RawShaderMaterial
   absorbHeight: THREE.RawShaderMaterial
   absorbPigment: THREE.RawShaderMaterial
@@ -74,7 +75,11 @@ export type MaterialMap = {
   absorbSettled: THREE.RawShaderMaterial
   diffuseWet: THREE.RawShaderMaterial
   composite: THREE.RawShaderMaterial
-  divergence: THREE.RawShaderMaterial
-  jacobi: THREE.RawShaderMaterial
-  project: THREE.RawShaderMaterial
+  lbmForce: THREE.RawShaderMaterial
+  lbmSplat: MaterialTriplet
+  lbmCollision: MaterialTriplet
+  lbmStreaming: MaterialTriplet
+  lbmMatch: MaterialTriplet
+  lbmMacroscopic: THREE.RawShaderMaterial
+  lbmDensity: THREE.RawShaderMaterial
 }


### PR DESCRIPTION
## Summary
- add shared MIN_RHO and DRY_THRESHOLD constants to the LBM shaders so splats, macroscopic reconstruction, and distribution matching avoid divisions by near-zero densities
- zero out external forcing and collision accelerations for texels whose density is below the dry threshold to keep vacuum cells quiescent
- reuse the same dry cutoff when rebuilding macroscopic velocity so near-empty regions no longer report spurious speeds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb709acdc48326ae2f921663f4407a