### PR TITLE
Add paper texture modulation to absorption

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,6 +122,7 @@ export default function Home() {
   const featureControls = useControls('Features', {
     stateAbsorption: { label: 'State Absorption', value: true },
     granulation: { label: 'Granulation', value: true },
+    paperTextureStrength: { label: 'Paper Texture Influence', value: 0.75, min: 0, max: 2, step: 0.01 },
   })
 
   useControls('Actions', {
@@ -148,7 +149,11 @@ export default function Home() {
     viscosity: number
     buoyancy: number
   }
-  const { stateAbsorption, granulation } = featureControls as { stateAbsorption: boolean; granulation: boolean }
+  const { stateAbsorption, granulation, paperTextureStrength } = featureControls as {
+    stateAbsorption: boolean
+    granulation: boolean
+    paperTextureStrength: number
+  }
   const { waterCapacityWater, waterCapacityPigment, pigmentCapacity, waterConsumption, pigmentConsumption, stampSpacing } = reservoirControls as {
     waterCapacityWater: number;
     waterCapacityPigment: number;
@@ -176,6 +181,7 @@ export default function Home() {
     backrunStrength,
     stateAbsorption,
     granulation,
+    paperTextureStrength,
     absorbExponent: DEFAULT_ABSORB_EXPONENT,
     absorbTimeOffset: DEFAULT_ABSORB_TIME_OFFSET,
     absorbMinFlux: DEFAULT_ABSORB_MIN_FLUX,
@@ -206,6 +212,7 @@ export default function Home() {
     backrunStrength,
     stateAbsorption,
     granulation,
+    paperTextureStrength,
     cfl,
     maxSubsteps,
     binderInjection,

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -77,7 +77,7 @@ Leva panels in the demo map directly to `SimulationParams` fields:
 - **Flow Dynamics** – Gravity, viscosity, CFL safety factor, and maximum adaptive substeps.
 - **Binder** – Runtime overrides for binder injection, diffusion, decay, elasticity, viscosity, and buoyancy.
 - **Brush Reservoir** – Water/pigment capacities and per-stamp consumption rates.
-- **Simulation Features** – Toggles for state-dependent absorption and granulation for debugging.
+- **Simulation Features** – Toggles for state-dependent absorption, granulation, and a scalar for paper-texture influence.
 
 ## References
 

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -63,7 +63,11 @@ function createTriplet(
   return fragments.map((fragment) => createMaterial(fragment, uniforms())) as MaterialTriplet
 }
 
-export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.DataTexture): MaterialMap {
+export function createMaterials(
+  texelSize: THREE.Vector2,
+  fiberTexture: THREE.DataTexture,
+  paperHeightTexture: THREE.DataTexture,
+): MaterialMap {
   const centerUniform = () => ({ value: new THREE.Vector2(0, 0) })
   const pigmentUniform = () => ({ value: new THREE.Vector3(0, 0, 0) })
 
@@ -115,6 +119,7 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uWet: { value: null },
     uDeposits: { value: null },
     uSettled: { value: null },
+    uPaperHeight: { value: paperHeightTexture },
     uAbsorb: { value: 0 },
     uEvap: { value: 0 },
     uEdge: { value: 0 },
@@ -127,6 +132,7 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uSettle: { value: 0 },
     uGranStrength: { value: GRANULATION_STRENGTH },
     uBackrunStrength: { value: 0 },
+    uPaperStrength: { value: 0 },
     uTexel: { value: texelSize.clone() },
   })
 

--- a/lib/watercolor/targets.ts
+++ b/lib/watercolor/targets.ts
@@ -2,6 +2,11 @@ import * as THREE from 'three'
 
 import { type PingPongTarget } from './types'
 
+export type PaperFieldTextures = {
+  fiber: THREE.DataTexture
+  height: THREE.DataTexture
+}
+
 export function createRenderTarget(size: number, type: THREE.TextureDataType) {
   const target = new THREE.WebGLRenderTarget(size, size, {
     type,
@@ -32,8 +37,9 @@ export function createPingPong(size: number, type: THREE.TextureDataType): PingP
   }
 }
 
-export function createFiberField(size: number): THREE.DataTexture {
-  const data = new Float32Array(size * size * 4)
+export function createPaperField(size: number): PaperFieldTextures {
+  const fiberData = new Float32Array(size * size * 4)
+  const heightData = new Float32Array(size * size * 4)
   for (let y = 0; y < size; y += 1) {
     for (let x = 0; x < size; x += 1) {
       const idx = (y * size + x) * 4
@@ -42,24 +48,47 @@ export function createFiberField(size: number): THREE.DataTexture {
       const nx = u - 0.5
       const ny = v - 0.5
       const swirl = Math.sin((nx + ny) * Math.PI * 4.0)
-      const wave = Math.cos((nx * 6.0) - (ny * 5.0))
+      const wave = Math.cos(nx * 6.0 - ny * 5.0)
       const angle = Math.atan2(ny, nx + 1e-6) * 0.35 + swirl * 0.6
       const dirX = Math.cos(angle)
       const dirY = Math.sin(angle)
       const dPara = 0.7 + 0.25 * wave
       const dPerp = 0.18 + 0.12 * Math.sin((nx - ny) * Math.PI * 6.0)
-      data[idx + 0] = dirX
-      data[idx + 1] = dirY
-      data[idx + 2] = Math.max(0.2, dPara)
-      data[idx + 3] = Math.max(0.05, dPerp)
+      fiberData[idx + 0] = dirX
+      fiberData[idx + 1] = dirY
+      fiberData[idx + 2] = Math.max(0.2, dPara)
+      fiberData[idx + 3] = Math.max(0.05, dPerp)
+
+      const radial = Math.sin((nx * nx + ny * ny) * 40.0)
+      const crossgrain = Math.sin((nx + ny) * Math.PI * 10.0) * Math.sin((nx - ny) * Math.PI * 7.0)
+      const baseHeight = 0.5 + 0.35 * swirl + 0.25 * wave
+      const detail = 0.12 * radial + 0.08 * crossgrain
+      const height = Math.min(Math.max(baseHeight + detail, 0.0), 1.0)
+      heightData[idx + 0] = height
+      heightData[idx + 1] = height
+      heightData[idx + 2] = height
+      heightData[idx + 3] = 1.0
     }
   }
-  const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat, THREE.FloatType)
-  texture.needsUpdate = true
-  texture.wrapS = THREE.RepeatWrapping
-  texture.wrapT = THREE.RepeatWrapping
-  texture.magFilter = THREE.LinearFilter
-  texture.minFilter = THREE.LinearFilter
-  texture.colorSpace = THREE.NoColorSpace
-  return texture
+  const fiberTexture = new THREE.DataTexture(fiberData, size, size, THREE.RGBAFormat, THREE.FloatType)
+  fiberTexture.needsUpdate = true
+  fiberTexture.wrapS = THREE.RepeatWrapping
+  fiberTexture.wrapT = THREE.RepeatWrapping
+  fiberTexture.magFilter = THREE.LinearFilter
+  fiberTexture.minFilter = THREE.LinearFilter
+  fiberTexture.colorSpace = THREE.NoColorSpace
+
+  const heightTexture = new THREE.DataTexture(heightData, size, size, THREE.RGBAFormat, THREE.FloatType)
+  heightTexture.needsUpdate = true
+  heightTexture.wrapS = THREE.RepeatWrapping
+  heightTexture.wrapT = THREE.RepeatWrapping
+  heightTexture.magFilter = THREE.LinearFilter
+  heightTexture.minFilter = THREE.LinearFilter
+  heightTexture.colorSpace = THREE.NoColorSpace
+
+  return { fiber: fiberTexture, height: heightTexture }
+}
+
+export function createFiberField(size: number): THREE.DataTexture {
+  return createPaperField(size).fiber
 }

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -37,6 +37,7 @@ export interface SimulationParams {
   stateAbsorption: boolean
   granulation: boolean
   backrunStrength: number
+  paperTextureStrength: number
   absorbExponent: number
   absorbTimeOffset: number
   absorbMinFlux: number


### PR DESCRIPTION
## Summary
- generate a reusable paper height texture alongside the fiber field and supply it to absorb materials
- sample the paper texture inside ABSORB_COMMON to bias deposition, settling, and granulation with an adjustable strength
- expose a paper texture influence control via SimulationParams, the UI, and documentation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cbe447e6d08326953225d94f80a3d2