### PR TITLE
Add paper height gating for watercolor splats

### DIFF
--- a/components/watercolor/WatercolorViewport.tsx
+++ b/components/watercolor/WatercolorViewport.tsx
@@ -144,6 +144,7 @@ const WatercolorViewport = ({
         const flowScale = 0.25 + 0.75 * waterRatio
         const scaledRadius = Math.max(brushState.radius * radiusScale, 1)
         const scaledFlow = brushState.flow * flowScale
+        const dryness = brushState.type === 'water' ? 0 : Math.min(1, Math.max(0, 1 - waterRatio))
 
         const color: [number, number, number] = brushState.type === 'pigment'
           ? [
@@ -159,6 +160,7 @@ const WatercolorViewport = ({
           flow: scaledFlow,
           type: brushState.type,
           color,
+          dryness,
         })
 
         const areaFactor = (scaledRadius / size) ** 2

--- a/lib/watercolor/WatercolorSimulation.ts
+++ b/lib/watercolor/WatercolorSimulation.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 
 import { createMaterials, createVelocityMaxMaterial } from './materials'
-import { createFiberField, createPingPong, createRenderTarget } from './targets'
+import { createFiberField, createPaperHeightField, createPingPong, createRenderTarget } from './targets'
 import {
   DEFAULT_BINDER_PARAMS,
   DEFAULT_DT,
@@ -40,6 +40,7 @@ export default class WatercolorSimulation {
   private readonly quad: THREE.Mesh<THREE.PlaneGeometry, THREE.RawShaderMaterial>
   private readonly materials: MaterialMap
   private readonly fiberTexture: THREE.DataTexture
+  private readonly paperHeightMap: THREE.DataTexture
   private readonly pressure: PingPongTarget
   private readonly divergence: THREE.WebGLRenderTarget
   private readonly pressureIterations = 20
@@ -74,11 +75,12 @@ export default class WatercolorSimulation {
     this.pressure = createPingPong(size, textureType)
     this.divergence = createRenderTarget(size, textureType)
     this.fiberTexture = createFiberField(size)
+    this.paperHeightMap = createPaperHeightField(size)
 
     this.scene = new THREE.Scene()
     this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
 
-    this.materials = createMaterials(this.texelSize, this.fiberTexture)
+    this.materials = createMaterials(this.texelSize, this.fiberTexture, this.paperHeightMap)
 
     this.quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), this.materials.zero)
     this.scene.add(this.quad)
@@ -94,10 +96,34 @@ export default class WatercolorSimulation {
     return this.compositeTarget.texture
   }
 
+  get paperHeightTexture(): THREE.DataTexture {
+    return this.paperHeightMap
+  }
+
   // Inject water or pigment into the simulation at a given position.
   splat(brush: BrushSettings) {
-    const { center, radius, flow, type, color } = brush
+    const { center, radius, flow, type, color, dryness = 0, dryThreshold } = brush
     const toolType = type === 'water' ? 0 : 1
+
+    const normalizedFlow = THREE.MathUtils.clamp(flow, 0, 1)
+    const dryBase = type === 'water' ? 0 : THREE.MathUtils.clamp(dryness, 0, 1)
+    const dryInfluence = THREE.MathUtils.clamp(dryBase * (1 - 0.55 * normalizedFlow), 0, 1)
+    const computedThreshold = THREE.MathUtils.lerp(-0.15, 0.7, dryInfluence)
+    const threshold = THREE.MathUtils.clamp(dryThreshold ?? computedThreshold, -0.25, 1.0)
+
+    const splatMaterials = [
+      this.materials.splatHeight,
+      this.materials.splatVelocity,
+      this.materials.splatPigment,
+      this.materials.splatBinder,
+    ]
+
+    splatMaterials.forEach((material) => {
+      const uniforms = material.uniforms as Record<string, THREE.IUniform>
+      uniforms.uPaperHeight.value = this.paperHeightMap
+      uniforms.uDryThreshold.value = threshold
+      uniforms.uDryInfluence.value = dryInfluence
+    })
 
     const splatHeight = this.materials.splatHeight
     splatHeight.uniforms.uSource.value = this.targets.H.read.texture
@@ -115,7 +141,6 @@ export default class WatercolorSimulation {
     splatVelocity.uniforms.uFlow.value = flow
     this.renderToTarget(splatVelocity, this.targets.UV.write)
     this.targets.UV.swap()
-
 
     const splatPigment = this.materials.splatPigment
     splatPigment.uniforms.uSource.value = this.targets.C.read.texture
@@ -393,6 +418,7 @@ export default class WatercolorSimulation {
     this.velocityMaxMaterial.dispose()
     this.clearTargets()
     this.fiberTexture.dispose()
+    this.paperHeightMap.dispose()
     this.velocityReductionTargets.forEach((target) => target.dispose())
   }
 

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -45,7 +45,10 @@ import { type MaterialMap } from './types'
 
 const sanitizeShader = (code: string) => code.trimStart()
 
-function createMaterial(fragmentShader: string, uniforms: Record<string, THREE.IUniform>): THREE.RawShaderMaterial {
+function createMaterial(
+  fragmentShader: string,
+  uniforms: Record<string, THREE.IUniform>,
+): THREE.RawShaderMaterial {
   return new THREE.RawShaderMaterial({
     uniforms,
     vertexShader: sanitizeShader(FULLSCREEN_VERTEX),
@@ -57,7 +60,11 @@ function createMaterial(fragmentShader: string, uniforms: Record<string, THREE.I
   })
 }
 
-export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.DataTexture): MaterialMap {
+export function createMaterials(
+  texelSize: THREE.Vector2,
+  fiberTexture: THREE.DataTexture,
+  paperHeightTexture: THREE.DataTexture,
+): MaterialMap {
   const centerUniform = () => ({ value: new THREE.Vector2(0, 0) })
   const pigmentUniform = () => ({ value: new THREE.Vector3(0, 0, 0) })
 
@@ -69,6 +76,9 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uRadius: { value: 0 },
     uFlow: { value: 0 },
     uToolType: { value: 0 },
+    uPaperHeight: { value: paperHeightTexture },
+    uDryThreshold: { value: 0.45 },
+    uDryInfluence: { value: 0 },
   })
 
   const splatVelocity = createMaterial(SPLAT_VELOCITY_FRAGMENT, {
@@ -76,6 +86,9 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uCenter: centerUniform(),
     uRadius: { value: 0 },
     uFlow: { value: 0 },
+    uPaperHeight: { value: paperHeightTexture },
+    uDryThreshold: { value: 0.45 },
+    uDryInfluence: { value: 0 },
   })
 
   const splatPigment = createMaterial(SPLAT_PIGMENT_FRAGMENT, {
@@ -85,6 +98,9 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uFlow: { value: 0 },
     uToolType: { value: 0 },
     uPigment: pigmentUniform(),
+    uPaperHeight: { value: paperHeightTexture },
+    uDryThreshold: { value: 0.45 },
+    uDryInfluence: { value: 0 },
   })
 
   const splatBinder = createMaterial(SPLAT_BINDER_FRAGMENT, {
@@ -94,6 +110,9 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uFlow: { value: 0 },
     uToolType: { value: 0 },
     uBinderStrength: { value: DEFAULT_BINDER_PARAMS.injection },
+    uPaperHeight: { value: paperHeightTexture },
+    uDryThreshold: { value: 0.45 },
+    uDryInfluence: { value: 0 },
   })
 
   const advectVelocity = createMaterial(ADVECT_VELOCITY_FRAGMENT, {

--- a/lib/watercolor/shaders.ts
+++ b/lib/watercolor/shaders.ts
@@ -25,10 +25,21 @@ uniform sampler2D uSource;
 uniform vec2 uCenter;
 uniform float uRadius;
 uniform float uFlow;
+uniform sampler2D uPaperHeight;
+uniform float uDryThreshold;
+uniform float uDryInfluence;
 float splatFalloff(vec2 uv, float radius) {
   vec2 delta = uv - uCenter;
   float r = max(radius, 1e-6);
   return exp(-9.0 * dot(delta, delta) / (r * r + 1e-6));
+}
+float paperDryGate(vec2 uv, float flow) {
+  float height = texture(uPaperHeight, uv).r;
+  float wetness = clamp(flow, 0.0, 1.0);
+  float dryMix = clamp(uDryInfluence, 0.0, 1.0);
+  float feather = mix(0.03, 0.18, 1.0 - wetness);
+  float ramp = smoothstep(uDryThreshold - feather, uDryThreshold + feather, height);
+  return mix(1.0, 1.0 - ramp, dryMix);
 }
 `
 
@@ -38,8 +49,9 @@ uniform float uToolType;
 void main() {
   vec4 src = texture(uSource, vUv);
   float fall = splatFalloff(vUv, uRadius);
+  float gate = paperDryGate(vUv, uFlow);
   float waterMul = mix(1.0, 0.7, step(0.5, uToolType));
-  src.r += waterMul * uFlow * fall;
+  src.r += waterMul * uFlow * fall * gate;
   fragColor = vec4(src.r, 0.0, 0.0, 1.0);
 }
 `
@@ -50,9 +62,10 @@ void main() {
   vec4 src = texture(uSource, vUv);
   vec2 delta = vUv - uCenter;
   float fall = splatFalloff(vUv, uRadius);
+  float gate = paperDryGate(vUv, uFlow);
   float len = length(delta);
   vec2 dir = len > 1e-6 ? delta / len : vec2(0.0);
-  vec2 dv = dir * (0.7 * uFlow * fall);
+  vec2 dv = dir * (0.7 * uFlow * fall * gate);
   fragColor = vec4(src.xy + dv, 0.0, 1.0);
 }
 `
@@ -64,8 +77,9 @@ uniform vec3 uPigment;
 void main() {
   vec4 src = texture(uSource, vUv);
   float fall = splatFalloff(vUv, uRadius);
+  float gate = paperDryGate(vUv, uFlow);
   float pigmentMask = step(0.5, uToolType);
-  vec3 add = uPigment * (uFlow * fall * pigmentMask);
+  vec3 add = uPigment * (uFlow * fall * pigmentMask * gate);
   fragColor = vec4(src.rgb + add, src.a);
 }
 `
@@ -77,8 +91,9 @@ uniform float uBinderStrength;
 void main() {
   vec4 src = texture(uSource, vUv);
   float fall = splatFalloff(vUv, uRadius);
+  float gate = paperDryGate(vUv, uFlow);
   float mask = step(0.5, uToolType);
-  float add = uBinderStrength * uFlow * fall * mask;
+  float add = uBinderStrength * uFlow * fall * mask * gate;
   fragColor = vec4(src.r + add, 0.0, 0.0, 1.0);
 }
 `

--- a/lib/watercolor/targets.ts
+++ b/lib/watercolor/targets.ts
@@ -63,3 +63,80 @@ export function createFiberField(size: number): THREE.DataTexture {
   texture.colorSpace = THREE.NoColorSpace
   return texture
 }
+
+export function createPaperHeightField(size: number): THREE.DataTexture {
+  const data = new Float32Array(size * size * 4)
+
+  const pseudoRandom = (x: number, y: number) => {
+    const n = Math.sin(x * 127.1 + y * 311.7) * 43758.5453123
+    return n - Math.floor(n)
+  }
+
+  const fade = (t: number) => t * t * (3 - 2 * t)
+  const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+
+  const valueNoise = (x: number, y: number) => {
+    const ix = Math.floor(x)
+    const iy = Math.floor(y)
+    const fx = x - ix
+    const fy = y - iy
+
+    const v00 = pseudoRandom(ix, iy)
+    const v10 = pseudoRandom(ix + 1, iy)
+    const v01 = pseudoRandom(ix, iy + 1)
+    const v11 = pseudoRandom(ix + 1, iy + 1)
+
+    const u = fade(fx)
+    const v = fade(fy)
+
+    const x0 = lerp(v00, v10, u)
+    const x1 = lerp(v01, v11, u)
+    return lerp(x0, x1, v)
+  }
+
+  const octaves = 4
+  const lacunarity = 2.07
+  const persistence = 0.55
+  const scale = 3.5
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const idx = (y * size + x) * 4
+      const u = x / size
+      const v = y / size
+
+      let amplitude = 1
+      let frequency = 1
+      let total = 0
+      let sum = 0
+
+      for (let octave = 0; octave < octaves; octave += 1) {
+        const nx = (u + 13.27) * frequency * scale
+        const ny = (v + 7.91) * frequency * scale
+        sum += valueNoise(nx, ny) * amplitude
+        total += amplitude
+        amplitude *= persistence
+        frequency *= lacunarity
+      }
+
+      let height = total > 0 ? sum / total : 0
+      height = Math.pow(height, 1.6)
+      height = THREE.MathUtils.clamp(height, 0, 1)
+
+      data[idx + 0] = height
+      data[idx + 1] = height
+      data[idx + 2] = height
+      data[idx + 3] = 1.0
+    }
+  }
+
+  const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat, THREE.FloatType)
+  texture.needsUpdate = true
+  texture.wrapS = THREE.RepeatWrapping
+  texture.wrapT = THREE.RepeatWrapping
+  texture.magFilter = THREE.LinearFilter
+  texture.minFilter = THREE.LinearFilter
+  texture.colorSpace = THREE.NoColorSpace
+  texture.name = 'PaperHeightField'
+  return texture
+}

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -8,6 +8,8 @@ export interface BrushSettings {
   flow: number
   type: BrushType
   color: [number, number, number]
+  dryness?: number
+  dryThreshold?: number
 }
 
 export interface BinderParams {


### PR DESCRIPTION
## Summary
- add a procedural paper height texture and expose it through `WatercolorSimulation`
- feed the paper height map and dry-threshold uniforms into splat materials/shaders to gate injections
- derive per-stroke dryness from the brush reservoir so splats respect paper height masking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe8e5e15c832697fedf2d74e799c7