### PR TITLE
Support channel-wise pigment diffusion and settling

### DIFF
--- a/lib/watercolor/WatercolorSimulation.ts
+++ b/lib/watercolor/WatercolorSimulation.ts
@@ -158,12 +158,25 @@ export default class WatercolorSimulation {
       cfl,
       maxSubsteps,
       binder,
+      pigmentCoefficients,
     } = params
 
     this.binderSettings = { ...binder }
 
     const substeps = this.determineSubsteps(cfl, maxSubsteps, dt)
     const substepDt = dt / substeps
+
+    const diffusionCoefficients = new THREE.Vector3(
+      pigmentCoefficients?.diffusion?.[0] ?? PIGMENT_DIFFUSION_COEFF,
+      pigmentCoefficients?.diffusion?.[1] ?? PIGMENT_DIFFUSION_COEFF,
+      pigmentCoefficients?.diffusion?.[2] ?? PIGMENT_DIFFUSION_COEFF,
+    )
+    const settleCoefficients = new THREE.Vector3(
+      pigmentCoefficients?.settle?.[0] ?? GRANULATION_SETTLE_RATE,
+      pigmentCoefficients?.settle?.[1] ?? GRANULATION_SETTLE_RATE,
+      pigmentCoefficients?.settle?.[2] ?? GRANULATION_SETTLE_RATE,
+    )
+    const settleVector = new THREE.Vector3()
 
     for (let i = 0; i < substeps; i += 1) {
       const advectBinder = this.materials.advectBinder
@@ -212,7 +225,9 @@ export default class WatercolorSimulation {
 
       const diffusePigment = this.materials.diffusePigment
       diffusePigment.uniforms.uPigment.value = this.targets.C.read.texture
-      diffusePigment.uniforms.uDiffusion.value = PIGMENT_DIFFUSION_COEFF
+      const diffusionUniform =
+        diffusePigment.uniforms.uDiffusion.value as THREE.Vector3
+      diffusionUniform.copy(diffusionCoefficients)
       diffusePigment.uniforms.uDt.value = substepDt
       this.renderToTarget(diffusePigment, this.targets.C.write)
       this.targets.C.swap()
@@ -222,9 +237,12 @@ export default class WatercolorSimulation {
       const edgeFactor = edge * substepDt
       const beta = stateAbsorption ? absorbExponent : 1.0
       const humidityInfluence = stateAbsorption ? HUMIDITY_INFLUENCE : 0.0
-      const settleBase = granulation ? GRANULATION_SETTLE_RATE : 0.0
       const granStrength = granulation ? GRANULATION_STRENGTH : 0.0
-      const settleFactor = settleBase * substepDt
+      if (granulation) {
+        settleVector.copy(settleCoefficients).multiplyScalar(substepDt)
+      } else {
+        settleVector.set(0, 0, 0)
+      }
       const timeOffset = stateAbsorption ? Math.max(absorbTimeOffset, 1e-4) : 1.0
       const absorbTime = stateAbsorption ? this.absorbElapsed + 0.5 * substepDt : 0
       const absorbFloor = stateAbsorption ? Math.max(absorbMinFlux, 0) * substepDt : 0
@@ -237,7 +255,7 @@ export default class WatercolorSimulation {
         absorbBase,
         evapFactor,
         edgeFactor,
-        settleFactor,
+        settleVector,
         beta,
         humidityInfluence,
         granStrength,
@@ -254,7 +272,7 @@ export default class WatercolorSimulation {
         absorbBase,
         evapFactor,
         edgeFactor,
-        settleFactor,
+        settleVector,
         beta,
         humidityInfluence,
         granStrength,
@@ -271,7 +289,7 @@ export default class WatercolorSimulation {
         absorbBase,
         evapFactor,
         edgeFactor,
-        settleFactor,
+        settleVector,
         beta,
         humidityInfluence,
         granStrength,
@@ -288,7 +306,7 @@ export default class WatercolorSimulation {
         absorbBase,
         evapFactor,
         edgeFactor,
-        settleFactor,
+        settleVector,
         beta,
         humidityInfluence,
         granStrength,
@@ -305,7 +323,7 @@ export default class WatercolorSimulation {
         absorbBase,
         evapFactor,
         edgeFactor,
-        settleFactor,
+        settleVector,
         beta,
         humidityInfluence,
         granStrength,
@@ -443,7 +461,7 @@ export default class WatercolorSimulation {
     absorb: number,
     evap: number,
     edge: number,
-    settle: number,
+    settle: THREE.Vector3,
     beta: number,
     humidity: number,
     granStrength: number,
@@ -464,7 +482,10 @@ export default class WatercolorSimulation {
     uniforms.uDepBase.value = DEPOSITION_BASE
     if (uniforms.uBeta) uniforms.uBeta.value = beta
     if (uniforms.uHumidity) uniforms.uHumidity.value = humidity
-    if (uniforms.uSettle) uniforms.uSettle.value = settle
+    if (uniforms.uSettle) {
+      const settleUniform = uniforms.uSettle.value as THREE.Vector3
+      settleUniform.copy(settle)
+    }
     if (uniforms.uGranStrength) uniforms.uGranStrength.value = granStrength
     if (uniforms.uBackrunStrength) uniforms.uBackrunStrength.value = backrunStrength
     if (uniforms.uAbsorbTime) uniforms.uAbsorbTime.value = absorbTime
@@ -542,7 +563,14 @@ export default class WatercolorSimulation {
   }
 }
 
-export type { BrushType, BrushSettings, SimulationParams, BinderParams } from './types'
+export type {
+  BrushType,
+  BrushSettings,
+  SimulationParams,
+  BinderParams,
+  PigmentCoefficients,
+  ChannelCoefficients,
+} from './types'
 export {
   DEFAULT_BINDER_PARAMS,
   DEFAULT_ABSORB_EXPONENT,

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -122,7 +122,13 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
   const diffusePigment = createMaterial(PIGMENT_DIFFUSION_FRAGMENT, {
     uPigment: { value: null },
     uTexel: { value: texelSize.clone() },
-    uDiffusion: { value: PIGMENT_DIFFUSION_COEFF },
+    uDiffusion: {
+      value: new THREE.Vector3(
+        PIGMENT_DIFFUSION_COEFF,
+        PIGMENT_DIFFUSION_COEFF,
+        PIGMENT_DIFFUSION_COEFF,
+      ),
+    },
     uDt: { value: DEFAULT_DT },
   })
 
@@ -159,7 +165,7 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uAbsorbTimeOffset: { value: DEFAULT_ABSORB_TIME_OFFSET },
     uAbsorbFloor: { value: DEFAULT_ABSORB_MIN_FLUX },
     uHumidity: { value: HUMIDITY_INFLUENCE },
-    uSettle: { value: 0 },
+    uSettle: { value: new THREE.Vector3(0, 0, 0) },
     uGranStrength: { value: GRANULATION_STRENGTH },
     uBackrunStrength: { value: 0 },
     uTexel: { value: texelSize.clone() },

--- a/lib/watercolor/shaders.ts
+++ b/lib/watercolor/shaders.ts
@@ -149,7 +149,7 @@ in vec2 vUv;
 out vec4 fragColor;
 uniform sampler2D uPigment;
 uniform vec2 uTexel;
-uniform float uDiffusion;
+uniform vec3 uDiffusion;
 uniform float uDt;
 
 vec3 sampleRGB(vec2 uv) {
@@ -165,7 +165,7 @@ void main() {
   vec3 bottom = sampleRGB(vUv - dv);
   vec3 top = sampleRGB(vUv + dv);
   vec3 laplacian = left + right + top + bottom - 4.0 * center.rgb;
-  vec3 diffused = center.rgb + uDiffusion * laplacian * uDt;
+  vec3 diffused = center.rgb + (uDiffusion * laplacian) * uDt;
   fragColor = vec4(max(diffused, vec3(0.0)), center.a);
 }
 `
@@ -249,7 +249,7 @@ uniform float uAbsorbTime;
 uniform float uAbsorbTimeOffset;
 uniform float uAbsorbFloor;
 uniform float uHumidity;
-uniform float uSettle;
+uniform vec3 uSettle;
 uniform float uGranStrength;
 uniform float uBackrunStrength;
 uniform vec2 uTexel;
@@ -309,7 +309,7 @@ AbsorbResult computeAbsorb(vec2 uv) {
   dep += bloomDep;
   pigment = max(pigment - bloomDep, vec3(0.0));
 
-  float settleRate = clamp(uSettle, 0.0, 1.0);
+  vec3 settleRate = clamp(uSettle, vec3(0.0), vec3(1.0));
   vec3 settleAdd = pigment * settleRate;
   pigment = max(pigment - settleAdd, vec3(0.0));
   vec3 settledNew = settled + settleAdd;

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -10,6 +10,13 @@ export interface BrushSettings {
   color: [number, number, number]
 }
 
+export type ChannelCoefficients = [number, number, number]
+
+export interface PigmentCoefficients {
+  diffusion: ChannelCoefficients
+  settle: ChannelCoefficients
+}
+
 export interface BinderParams {
   injection: number
   diffusion: number
@@ -44,6 +51,7 @@ export interface SimulationParams {
   maxSubsteps: number
   binder: BinderParams
   reservoir: ReservoirParams
+  pigmentCoefficients?: PigmentCoefficients
 }
 
 type SwapTarget = {


### PR DESCRIPTION
## Summary
- update pigment diffusion and absorption shaders to use vector uniforms for per-channel coefficients
- initialize new vector uniforms and extend simulation parameters with optional pigment coefficients
- propagate per-channel diffusion and settling settings through the simulation pipeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe8e825c883268c8eedd2edccfaa1