### PR TITLE
Add water rewet splat pass

### DIFF
--- a/lib/watercolor/WatercolorSimulation.ts
+++ b/lib/watercolor/WatercolorSimulation.ts
@@ -137,6 +137,25 @@ export default class WatercolorSimulation {
     this.renderToTarget(splatBinder, this.targets.B.write)
     this.targets.B.swap()
 
+    if (toolType === 0 && flow > 0) {
+      const rewetPigment = this.materials.splatRewetPigment
+      rewetPigment.uniforms.uSource.value = this.targets.C.read.texture
+      rewetPigment.uniforms.uDeposits.value = this.targets.DEP.read.texture
+      rewetPigment.uniforms.uCenter.value.set(center[0], center[1])
+      rewetPigment.uniforms.uRadius.value = radius
+      rewetPigment.uniforms.uFlow.value = flow
+      this.renderToTarget(rewetPigment, this.targets.C.write)
+      this.targets.C.swap()
+
+      const rewetDeposit = this.materials.splatRewetDeposit
+      rewetDeposit.uniforms.uSource.value = this.targets.DEP.read.texture
+      rewetDeposit.uniforms.uCenter.value.set(center[0], center[1])
+      rewetDeposit.uniforms.uRadius.value = radius
+      rewetDeposit.uniforms.uFlow.value = flow
+      this.renderToTarget(rewetDeposit, this.targets.DEP.write)
+      this.targets.DEP.swap()
+    }
+
     const absorbReset = toolType === 0 ? 0.3 : 0.15
     this.absorbElapsed = Math.max(0, this.absorbElapsed - absorbReset * flow)
   }
@@ -548,4 +567,6 @@ export {
   DEFAULT_ABSORB_EXPONENT,
   DEFAULT_ABSORB_TIME_OFFSET,
   DEFAULT_ABSORB_MIN_FLUX,
+  DEFAULT_REWET_STRENGTH,
+  PIGMENT_REWET,
 } from './constants'

--- a/lib/watercolor/constants.ts
+++ b/lib/watercolor/constants.ts
@@ -14,6 +14,11 @@ export const DEFAULT_ABSORB_MIN_FLUX = 0.02
 export const HUMIDITY_INFLUENCE = 0.6
 export const GRANULATION_SETTLE_RATE = 0.28
 export const GRANULATION_STRENGTH = 0.45
+export const DEFAULT_REWET_STRENGTH = 0.45
+
+// Per-pigment rewet multipliers – higher values dissolve more deposits when water is added.
+// Staining pigments can opt out by setting their channel to zero.
+export const PIGMENT_REWET = new THREE.Vector3(0.75, 0.6, 0.0)
 
 export const PIGMENT_K = [
   new THREE.Vector3(1.6, 0.1, 0.1),

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -21,6 +21,8 @@ import {
   SPLAT_BINDER_FRAGMENT,
   SPLAT_HEIGHT_FRAGMENT,
   SPLAT_PIGMENT_FRAGMENT,
+  SPLAT_REWET_DEPOSIT_FRAGMENT,
+  SPLAT_REWET_PIGMENT_FRAGMENT,
   SPLAT_VELOCITY_FRAGMENT,
   ZERO_FRAGMENT,
   VELOCITY_MAX_FRAGMENT,
@@ -30,6 +32,7 @@ import {
   DEFAULT_ABSORB_MIN_FLUX,
   DEFAULT_ABSORB_TIME_OFFSET,
   DEFAULT_BINDER_PARAMS,
+  DEFAULT_REWET_STRENGTH,
   DEFAULT_DT,
   DEPOSITION_BASE,
   GRANULATION_STRENGTH,
@@ -39,6 +42,7 @@ import {
   PAPER_DIFFUSION_STRENGTH,
   PIGMENT_DIFFUSION_COEFF,
   PIGMENT_K,
+  PIGMENT_REWET,
   PIGMENT_S,
 } from './constants'
 import { type MaterialMap } from './types'
@@ -94,6 +98,25 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     uFlow: { value: 0 },
     uToolType: { value: 0 },
     uBinderStrength: { value: DEFAULT_BINDER_PARAMS.injection },
+  })
+
+  const splatRewetPigment = createMaterial(SPLAT_REWET_PIGMENT_FRAGMENT, {
+    uSource: { value: null },
+    uDeposits: { value: null },
+    uCenter: centerUniform(),
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uRewetStrength: { value: DEFAULT_REWET_STRENGTH },
+    uRewetPerChannel: { value: PIGMENT_REWET.clone() },
+  })
+
+  const splatRewetDeposit = createMaterial(SPLAT_REWET_DEPOSIT_FRAGMENT, {
+    uSource: { value: null },
+    uCenter: centerUniform(),
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uRewetStrength: { value: DEFAULT_REWET_STRENGTH },
+    uRewetPerChannel: { value: PIGMENT_REWET.clone() },
   })
 
   const advectVelocity = createMaterial(ADVECT_VELOCITY_FRAGMENT, {
@@ -211,6 +234,8 @@ export function createMaterials(texelSize: THREE.Vector2, fiberTexture: THREE.Da
     splatVelocity,
     splatPigment,
     splatBinder,
+    splatRewetPigment,
+    splatRewetDeposit,
     advectVelocity,
     advectHeight,
     advectPigment,

--- a/lib/watercolor/shaders.ts
+++ b/lib/watercolor/shaders.ts
@@ -83,6 +83,38 @@ void main() {
 }
 `
 
+export const SPLAT_REWET_PIGMENT_FRAGMENT = `
+${SPLAT_COMMON}
+uniform sampler2D uDeposits;
+uniform float uRewetStrength;
+uniform vec3 uRewetPerChannel;
+void main() {
+  vec4 src = texture(uSource, vUv);
+  vec3 dep = texture(uDeposits, vUv).rgb;
+  float fall = splatFalloff(vUv, uRadius);
+  float fraction = clamp(uRewetStrength * uFlow * fall, 0.0, 1.0);
+  vec3 weights = clamp(uRewetPerChannel, vec3(0.0), vec3(1.0));
+  vec3 dissolved = min(dep, dep * (weights * fraction));
+  fragColor = vec4(src.rgb + dissolved, src.a);
+}
+`
+
+export const SPLAT_REWET_DEPOSIT_FRAGMENT = `
+${SPLAT_COMMON}
+uniform float uRewetStrength;
+uniform vec3 uRewetPerChannel;
+void main() {
+  vec4 src = texture(uSource, vUv);
+  vec3 dep = src.rgb;
+  float fall = splatFalloff(vUv, uRadius);
+  float fraction = clamp(uRewetStrength * uFlow * fall, 0.0, 1.0);
+  vec3 weights = clamp(uRewetPerChannel, vec3(0.0), vec3(1.0));
+  vec3 dissolved = min(dep, dep * (weights * fraction));
+  vec3 newDep = max(dep - dissolved, vec3(0.0));
+  fragColor = vec4(newDep, 1.0);
+}
+`
+
 export const ADVECT_VELOCITY_FRAGMENT = `
 precision highp float;
 in vec2 vUv;

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -61,6 +61,8 @@ export type MaterialMap = {
   splatVelocity: THREE.RawShaderMaterial
   splatPigment: THREE.RawShaderMaterial
   splatBinder: THREE.RawShaderMaterial
+  splatRewetPigment: THREE.RawShaderMaterial
+  splatRewetDeposit: THREE.RawShaderMaterial
   advectVelocity: THREE.RawShaderMaterial
   advectHeight: THREE.RawShaderMaterial
   advectPigment: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- add configurable rewet strength constants so staining pigments can opt out of reactivation
- create pigment/deposit rewet splat shaders and register the materials for use during water splats
- trigger the rewet pass for water strokes to dissolve deposits back into the dissolved pigment buffer while keeping the solver stable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe8e879f48326a8dff7454b3219df