### PR TITLE
Add paste stroke low-solvent dynamics and controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,6 +68,11 @@ export default function Home() {
       step: 0.01,
     },
   })
+  const pasteControls = useControls('Paste Strokes', {
+    pasteMode: { label: 'Enable Paste Mode', value: false },
+    pasteBinderBoost: { label: 'Binder Boost', value: 4, min: 1, max: 12, step: 0.1 },
+    pastePigmentBoost: { label: 'Pigment Boost', value: 2.5, min: 1, max: 10, step: 0.1 },
+  })
   const dryingControls = useControls('Drying & Deposits', {
     evap: { label: 'Evaporation', value: 0.02, min: 0, max: 1, step: 0.001 },
     absorb: { label: 'Absorption', value: 0.25, min: 0, max: 2, step: 0.001 },
@@ -163,6 +168,11 @@ export default function Home() {
     buoyancy: number
   }
   const { binderCharge, waterLoad } = mediumControls as { binderCharge: number; waterLoad: number }
+  const { pasteMode, pasteBinderBoost, pastePigmentBoost } = pasteControls as {
+    pasteMode: boolean
+    pasteBinderBoost: number
+    pastePigmentBoost: number
+  }
   const { stateAbsorption, granulation, paperTextureStrength } = featureControls as {
     stateAbsorption: boolean
     granulation: boolean
@@ -182,7 +192,10 @@ export default function Home() {
     flow,
     type: toolToBrushType(tool),
     color: pigmentIndex >= 0 ? PIGMENT_MASS[pigmentIndex] : ([0, 0, 0] as [number, number, number]),
-  }), [radius, flow, tool, pigmentIndex])
+    pasteMode,
+    binderBoost: pasteBinderBoost,
+    pigmentBoost: pastePigmentBoost,
+  }), [radius, flow, tool, pigmentIndex, pasteMode, pasteBinderBoost, pastePigmentBoost])
 
   const params = useMemo<SimulationParams>(() => ({
     grav,
@@ -265,7 +278,7 @@ export default function Home() {
                   background: `rgb(${PIGMENT_SWATCH[pigmentIndex][0] * 255}, ${PIGMENT_SWATCH[pigmentIndex][1] * 255}, ${PIGMENT_SWATCH[pigmentIndex][2] * 255})`,
                 }}
               />
-              <span>Pigment active</span>
+              <span>{pasteMode ? 'Paste mode' : 'Pigment active'}</span>
             </div>
           )}
         </div>

--- a/components/watercolor/WatercolorViewport.tsx
+++ b/components/watercolor/WatercolorViewport.tsx
@@ -10,6 +10,9 @@ type BrushSettings = {
   flow: number
   type: BrushType
   color: [number, number, number]
+  pasteMode?: boolean
+  binderBoost?: number
+  pigmentBoost?: number
 }
 
 type WatercolorViewportProps = {
@@ -144,7 +147,13 @@ const WatercolorViewport = ({
         const flowScale = 0.25 + 0.75 * waterRatio
         const scaledRadius = Math.max(brushState.radius * radiusScale, 1)
         const scaledFlow = brushState.flow * flowScale
-        const dryness = brushState.type === 'water' ? 0 : Math.min(1, Math.max(0, 1 - waterRatio))
+        const baseDryness =
+          brushState.type === 'water' ? 0 : Math.min(1, Math.max(0, 1 - waterRatio))
+        const reservoirSolvent = baseDryness > 0.75 ? baseDryness : 0
+        const pasteActive = brushState.type === 'pigment' && brushState.pasteMode
+        const lowSolvent = pasteActive ? 1 : reservoirSolvent
+        const dryness = pasteActive ? Math.max(baseDryness, 0.92) : baseDryness
+        const dryThreshold = lowSolvent > 0 ? 0.82 : undefined
 
         const color: [number, number, number] = brushState.type === 'pigment'
           ? [
@@ -161,6 +170,10 @@ const WatercolorViewport = ({
           type: brushState.type,
           color,
           dryness,
+          dryThreshold,
+          lowSolvent,
+          binderBoost: brushState.binderBoost,
+          pigmentBoost: brushState.pigmentBoost,
         })
 
         const areaFactor = (scaledRadius / size) ** 2

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -19,6 +19,7 @@ import {
   PRESSURE_JACOBI_FRAGMENT,
   PRESSURE_PROJECT_FRAGMENT,
   SPLAT_BINDER_FRAGMENT,
+  SPLAT_DEPOSIT_FRAGMENT,
   SPLAT_HEIGHT_FRAGMENT,
   SPLAT_PIGMENT_FRAGMENT,
   SPLAT_REWET_DEPOSIT_FRAGMENT,
@@ -102,6 +103,8 @@ export function createMaterials(
     uFlow: { value: 0 },
     uToolType: { value: 0 },
     uPigment: pigmentUniform(),
+    uLowSolvent: { value: 0 },
+    uBoost: { value: 1 },
     uPaperHeight: { value: paperHeightTexture },
     uDryThreshold: { value: 0.45 },
     uDryInfluence: { value: 0 },
@@ -114,6 +117,20 @@ export function createMaterials(
     uFlow: { value: 0 },
     uToolType: { value: 0 },
     uBinderStrength: { value: DEFAULT_BINDER_PARAMS.injection },
+    uLowSolvent: { value: 0 },
+    uPaperHeight: { value: paperHeightTexture },
+    uDryThreshold: { value: 0.45 },
+    uDryInfluence: { value: 0 },
+  })
+
+  const splatDeposit = createMaterial(SPLAT_DEPOSIT_FRAGMENT, {
+    uSource: { value: null },
+    uCenter: centerUniform(),
+    uRadius: { value: 0 },
+    uFlow: { value: 0 },
+    uPigment: pigmentUniform(),
+    uLowSolvent: { value: 0 },
+    uBoost: { value: 1 },
     uPaperHeight: { value: paperHeightTexture },
     uDryThreshold: { value: 0.45 },
     uDryInfluence: { value: 0 },
@@ -190,6 +207,9 @@ export function createMaterials(
     uDt: { value: DEFAULT_DT },
     uElasticity: { value: DEFAULT_BINDER_PARAMS.elasticity },
     uViscosity: { value: DEFAULT_BINDER_PARAMS.viscosity },
+    uLowSolvent: { value: 0 },
+    uPasteClamp: { value: 0.1 },
+    uPasteDamping: { value: 0.85 },
   })
 
   const absorbUniforms = () => ({
@@ -261,6 +281,7 @@ export function createMaterials(
     splatVelocity,
     splatPigment,
     splatBinder,
+    splatDeposit,
     splatRewetPigment,
     splatRewetDeposit,
     advectVelocity,

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -10,6 +10,10 @@ export interface BrushSettings {
   color: [number, number, number]
   dryness?: number
   dryThreshold?: number
+  lowSolvent?: number
+  binderBoost?: number
+  pigmentBoost?: number
+  depositBoost?: number
 }
 
 export type ChannelCoefficients = [number, number, number]
@@ -72,6 +76,7 @@ export type MaterialMap = {
   splatVelocity: THREE.RawShaderMaterial
   splatPigment: THREE.RawShaderMaterial
   splatBinder: THREE.RawShaderMaterial
+  splatDeposit: THREE.RawShaderMaterial
   splatRewetPigment: THREE.RawShaderMaterial
   splatRewetDeposit: THREE.RawShaderMaterial
   advectVelocity: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- add a paste mode control surface so artists can toggle paste strokes and tune binder/pigment boosts
- derive a low-solvent metric in the viewport to drive binder, pigment, and deposit injection for paste marks and accelerated drying
- update simulation shaders and binder forces to clamp velocities and deposit pigment/binder aggressively when paste mode is active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfd8f4a1c8326ad0e0c78fe7f955a