### PR TITLE
Add spatter brush mode with droplet batching

### DIFF
--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -1,16 +1,28 @@
 import * as THREE from 'three'
 
-export type BrushType = 'water' | 'pigment'
+export type BrushType = 'water' | 'pigment' | 'spatter'
 
-export interface BrushSettings {
+export interface BaseBrushSettings {
   center: [number, number]
   radius: number
   flow: number
-  type: BrushType
   color: [number, number, number]
   dryness?: number
   dryThreshold?: number
 }
+
+export interface SpatterSettings {
+  dropletCount: number
+  dropletJitter: number
+  spread: number
+  spreadAngle: number
+  sizeRange: [number, number]
+  flowJitter: number
+}
+
+export type BrushSettings =
+  | (BaseBrushSettings & { type: 'water' | 'pigment' })
+  | (BaseBrushSettings & { type: 'spatter'; spatter: SpatterSettings })
 
 export type ChannelCoefficients = [number, number, number]
 


### PR DESCRIPTION
## Summary
- add a spatter brush mode with Leva controls for droplet count, spread, and variation
- scatter spatter strokes into randomized droplet batches and submit them efficiently via the simulation
- extend watercolor brush types with spatter metadata and expose a batch splat helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfb9e8d7883268aa4f9f494c63b9e