### PR TITLE
Add watercolor spatter brush mode

### DIFF
--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 
-export type BrushType = 'water' | 'pigment'
+export type BrushType = 'water' | 'pigment' | 'spatter'
 
 export interface BrushMaskParams {
   texture: THREE.Texture | null


### PR DESCRIPTION
## Summary
- add a spatter brush tool with UI controls for droplet density, spread, and size distribution
- emit randomized droplet batches in the viewport when the spatter brush is active and update reservoir handling
- allow the watercolor simulation brush type to represent spatter strokes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfa4e8e708326b99be92a1ab287c0