### PR TITLE
Add surface tension relaxation pass with UI controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_ABSORB_TIME_OFFSET,
   DEFAULT_BINDER_PARAMS,
   DEFAULT_PAPER_TEXTURE_STRENGTH,
+  DEFAULT_SURFACE_TENSION_PARAMS,
   type BrushType,
   type SimulationParams,
 } from '@/lib/watercolor/WatercolorSimulation'
@@ -215,6 +216,48 @@ export default function Home() {
     maxSubsteps: { label: 'Max Substeps', value: 4, min: 1, max: 8, step: 1 },
   })
 
+  const surfaceTensionControls = useControls('Surface Tension', {
+    enabled: {
+      label: 'Enable Surface Tension',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.enabled,
+    },
+    strength: {
+      label: 'Strength',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.strength,
+      min: 0,
+      max: 8,
+      step: 0.05,
+    },
+    threshold: {
+      label: 'Neighbour Threshold',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.threshold,
+      min: 0,
+      max: 0.5,
+      step: 0.005,
+    },
+    breakThreshold: {
+      label: 'Break Threshold',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.breakThreshold,
+      min: 0,
+      max: 0.2,
+      step: 0.001,
+    },
+    snapStrength: {
+      label: 'Snap Strength',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.snapStrength,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    },
+    velocityLimit: {
+      label: 'Velocity Limit',
+      value: DEFAULT_SURFACE_TENSION_PARAMS.velocityLimit,
+      min: 0.01,
+      max: 2,
+      step: 0.01,
+    },
+  })
+
   const binderControls = useControls('Binder Dynamics', {
     diffusion: {
       label: 'Diffusion',
@@ -285,6 +328,21 @@ export default function Home() {
   const streakDensity = brushControls.streakDensity as number
   const { evap, absorb, edge, backrunStrength } = dryingControls as { evap: number; absorb: number; edge: number; backrunStrength: number }
   const { grav, visc, cfl, maxSubsteps } = dynamicsControls as { grav: number; visc: number; cfl: number; maxSubsteps: number }
+  const {
+    enabled: surfaceTensionEnabled,
+    strength: surfaceTensionStrength,
+    threshold: surfaceTensionThreshold,
+    breakThreshold: surfaceTensionBreakThreshold,
+    snapStrength: surfaceTensionSnapStrength,
+    velocityLimit: surfaceTensionVelocityLimit,
+  } = surfaceTensionControls as {
+    enabled: boolean
+    strength: number
+    threshold: number
+    breakThreshold: number
+    snapStrength: number
+    velocityLimit: number
+  }
   const {
     diffusion: binderDiffusion,
     decay: binderDecay,
@@ -443,6 +501,14 @@ export default function Home() {
       viscosity: binderViscosity,
       buoyancy: binderBuoyancy,
     },
+    surfaceTension: {
+      enabled: surfaceTensionEnabled,
+      strength: surfaceTensionStrength,
+      threshold: surfaceTensionThreshold,
+      breakThreshold: surfaceTensionBreakThreshold,
+      snapStrength: surfaceTensionSnapStrength,
+      velocityLimit: surfaceTensionVelocityLimit,
+    },
     reservoir: {
       waterCapacityWater,
       waterCapacityPigment: waterLoad,
@@ -469,6 +535,12 @@ export default function Home() {
     binderElasticity,
     binderViscosity,
     binderBuoyancy,
+    surfaceTensionEnabled,
+    surfaceTensionStrength,
+    surfaceTensionThreshold,
+    surfaceTensionBreakThreshold,
+    surfaceTensionSnapStrength,
+    surfaceTensionVelocityLimit,
     waterCapacityWater,
     waterLoad,
     pigmentCapacity,

--- a/lib/watercolor/constants.ts
+++ b/lib/watercolor/constants.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 
-import { type BinderParams } from './types'
+import { type BinderParams, type SurfaceTensionParams } from './types'
 
 export const DEFAULT_DT = 1 / 90
 export const DEPOSITION_BASE = 0.02
@@ -41,4 +41,13 @@ export const DEFAULT_BINDER_PARAMS: BinderParams = {
   elasticity: 1.25,
   viscosity: 0.65,
   buoyancy: 0.12,
+}
+
+export const DEFAULT_SURFACE_TENSION_PARAMS: SurfaceTensionParams = {
+  enabled: true,
+  strength: 2.8,
+  threshold: 0.12,
+  breakThreshold: 0.025,
+  snapStrength: 0.6,
+  velocityLimit: 0.65,
 }

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -25,6 +25,7 @@ import {
   SPLAT_REWET_DEPOSIT_FRAGMENT,
   SPLAT_REWET_PIGMENT_FRAGMENT,
   SPLAT_VELOCITY_FRAGMENT,
+  SURFACE_TENSION_FRAGMENT,
   ZERO_FRAGMENT,
   VELOCITY_MAX_FRAGMENT,
 } from './shaders'
@@ -33,6 +34,7 @@ import {
   DEFAULT_ABSORB_MIN_FLUX,
   DEFAULT_ABSORB_TIME_OFFSET,
   DEFAULT_BINDER_PARAMS,
+  DEFAULT_SURFACE_TENSION_PARAMS,
   DEFAULT_REWET_STRENGTH,
   DEFAULT_DT,
   DEPOSITION_BASE,
@@ -199,6 +201,19 @@ export function createMaterials(
     uBinderBuoyancy: { value: DEFAULT_BINDER_PARAMS.buoyancy },
   })
 
+  const surfaceTension = createMaterial(SURFACE_TENSION_FRAGMENT, {
+    uHeight: { value: null },
+    uWet: { value: null },
+    uVelocity: { value: null },
+    uTexel: { value: texelSize.clone() },
+    uDt: { value: DEFAULT_DT },
+    uStrength: { value: DEFAULT_SURFACE_TENSION_PARAMS.strength },
+    uThreshold: { value: DEFAULT_SURFACE_TENSION_PARAMS.threshold },
+    uBreakThreshold: { value: DEFAULT_SURFACE_TENSION_PARAMS.breakThreshold },
+    uSnapStrength: { value: DEFAULT_SURFACE_TENSION_PARAMS.snapStrength },
+    uVelocityLimit: { value: DEFAULT_SURFACE_TENSION_PARAMS.velocityLimit },
+  })
+
   const advectPigment = createMaterial(ADVECT_PIGMENT_FRAGMENT, {
     uPigment: { value: null },
     uVelocity: { value: null },
@@ -313,6 +328,7 @@ export function createMaterials(
     splatRewetDeposit,
     advectVelocity,
     advectHeight,
+    surfaceTension,
     advectPigment,
     diffusePigment,
     advectBinder,

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -49,6 +49,15 @@ export interface ReservoirParams {
   stampSpacing: number
 }
 
+export interface SurfaceTensionParams {
+  enabled: boolean
+  strength: number
+  threshold: number
+  breakThreshold: number
+  snapStrength: number
+  velocityLimit: number
+}
+
 export interface SimulationParams {
   grav: number
   visc: number
@@ -66,6 +75,7 @@ export interface SimulationParams {
   maxSubsteps: number
   binder: BinderParams
   reservoir: ReservoirParams
+  surfaceTension: SurfaceTensionParams
   pigmentCoefficients?: PigmentCoefficients
 }
 
@@ -89,6 +99,7 @@ export type MaterialMap = {
   splatRewetDeposit: THREE.RawShaderMaterial
   advectVelocity: THREE.RawShaderMaterial
   advectHeight: THREE.RawShaderMaterial
+  surfaceTension: THREE.RawShaderMaterial
   advectPigment: THREE.RawShaderMaterial
   diffusePigment: THREE.RawShaderMaterial
   advectBinder: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- add a surface tension fragment shader that contracts thin filaments after projection and respects new tuning uniforms
- register the pass, defaults, and simulation parameter plumbing so the solver and UI expose surface tension settings
- document the new pipeline stage along with tuning guidance in the overview

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6ead6a508326a2e3e8a4e8337011