### PR TITLE
Add evaporation ring redistribution effect

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_SIZING_INFLUENCE,
   DEFAULT_SURFACE_TENSION_PARAMS,
   DEFAULT_FRINGE_PARAMS,
+  DEFAULT_RING_PARAMS,
   type BrushType,
   type SimulationParams,
 } from '@/lib/watercolor/WatercolorSimulation'
@@ -325,6 +326,38 @@ export default function Home() {
     },
   })
 
+  const ringControls = useControls('Evaporation Rings', {
+    enabled: { label: 'Enable Rings', value: DEFAULT_RING_PARAMS.enabled },
+    strength: {
+      label: 'Strength',
+      value: DEFAULT_RING_PARAMS.strength,
+      min: 0,
+      max: 6,
+      step: 0.05,
+    },
+    filmThreshold: {
+      label: 'Film Threshold',
+      value: DEFAULT_RING_PARAMS.filmThreshold,
+      min: 0.01,
+      max: 0.2,
+      step: 0.005,
+    },
+    filmFeather: {
+      label: 'Film Feather',
+      value: DEFAULT_RING_PARAMS.filmFeather,
+      min: 0.01,
+      max: 0.12,
+      step: 0.005,
+    },
+    gradientScale: {
+      label: 'Gradient Scale',
+      value: DEFAULT_RING_PARAMS.gradientScale,
+      min: 1,
+      max: 24,
+      step: 0.5,
+    },
+  })
+
   const fringeControls = useControls('Capillary Fringe', {
     enabled: { label: 'Enable Fringe', value: DEFAULT_FRINGE_PARAMS.enabled },
     strength: {
@@ -425,6 +458,19 @@ export default function Home() {
     stateAbsorption: boolean
     granulation: boolean
     paperTextureStrength: number
+  }
+  const {
+    enabled: ringEnabled,
+    strength: ringStrength,
+    filmThreshold: ringFilmThreshold,
+    filmFeather: ringFilmFeather,
+    gradientScale: ringGradientScale,
+  } = ringControls as {
+    enabled: boolean
+    strength: number
+    filmThreshold: number
+    filmFeather: number
+    gradientScale: number
   }
   const {
     enabled: fringeEnabled,
@@ -567,6 +613,13 @@ export default function Home() {
       threshold: fringeThreshold,
       noiseScale: fringeNoiseScale,
     },
+    evaporationRings: {
+      enabled: ringEnabled,
+      strength: ringStrength,
+      filmThreshold: ringFilmThreshold,
+      filmFeather: ringFilmFeather,
+      gradientScale: ringGradientScale,
+    },
     reservoir: {
       waterCapacityWater,
       waterCapacityPigment: waterLoad,
@@ -604,6 +657,11 @@ export default function Home() {
     fringeStrength,
     fringeThreshold,
     fringeNoiseScale,
+    ringEnabled,
+    ringStrength,
+    ringFilmThreshold,
+    ringFilmFeather,
+    ringGradientScale,
     waterCapacityWater,
     waterLoad,
     pigmentCapacity,

--- a/lib/watercolor/constants.ts
+++ b/lib/watercolor/constants.ts
@@ -1,6 +1,11 @@
 import * as THREE from 'three'
 
-import { type BinderParams, type CapillaryFringeParams, type SurfaceTensionParams } from './types'
+import {
+  type BinderParams,
+  type CapillaryFringeParams,
+  type EvaporationRingParams,
+  type SurfaceTensionParams,
+} from './types'
 
 export const DEFAULT_DT = 1 / 90
 export const DEPOSITION_BASE = 0.02
@@ -58,4 +63,12 @@ export const DEFAULT_FRINGE_PARAMS: CapillaryFringeParams = {
   strength: 0.65,
   threshold: 0.18,
   noiseScale: 32,
+}
+
+export const DEFAULT_RING_PARAMS: EvaporationRingParams = {
+  enabled: true,
+  strength: 2.4,
+  filmThreshold: 0.075,
+  filmFeather: 0.045,
+  gradientScale: 12,
 }

--- a/lib/watercolor/materials.ts
+++ b/lib/watercolor/materials.ts
@@ -12,6 +12,7 @@ import {
   ADVECT_VELOCITY_FRAGMENT,
   BINDER_FORCE_FRAGMENT,
   COMPOSITE_FRAGMENT,
+  EVAPORATION_RING_FRAGMENT,
   FULLSCREEN_VERTEX,
   PAPER_DIFFUSION_FRAGMENT,
   PIGMENT_DIFFUSION_FRAGMENT,
@@ -39,6 +40,7 @@ import {
   DEFAULT_DT,
   DEPOSITION_BASE,
   DEFAULT_FRINGE_PARAMS,
+  DEFAULT_RING_PARAMS,
   GRANULATION_STRENGTH,
   HUMIDITY_INFLUENCE,
   KM_LAYER_SCALE,
@@ -287,6 +289,18 @@ export function createMaterials(
   const absorbWet = createMaterial(ABSORB_WET_FRAGMENT, absorbUniforms())
   const absorbSettled = createMaterial(ABSORB_SETTLED_FRAGMENT, absorbUniforms())
 
+  const evaporationRings = createMaterial(EVAPORATION_RING_FRAGMENT, {
+    uDeposits: { value: null },
+    uWet: { value: null },
+    uHeight: { value: null },
+    uTexel: { value: texelSize.clone() },
+    uStrength: { value: DEFAULT_RING_PARAMS.strength },
+    uDt: { value: DEFAULT_DT },
+    uFilmThreshold: { value: DEFAULT_RING_PARAMS.filmThreshold },
+    uFilmFeather: { value: DEFAULT_RING_PARAMS.filmFeather },
+    uGradientScale: { value: DEFAULT_RING_PARAMS.gradientScale },
+  })
+
   const diffuseWet = createMaterial(PAPER_DIFFUSION_FRAGMENT, {
     uWet: { value: null },
     uFiber: { value: fiberTexture },
@@ -345,6 +359,7 @@ export function createMaterials(
     absorbPigment,
     absorbWet,
     absorbSettled,
+    evaporationRings,
     diffuseWet,
     composite,
     divergence,

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -65,6 +65,14 @@ export interface CapillaryFringeParams {
   noiseScale: number
 }
 
+export interface EvaporationRingParams {
+  enabled: boolean
+  strength: number
+  filmThreshold: number
+  filmFeather: number
+  gradientScale: number
+}
+
 export interface SimulationParams {
   grav: number
   visc: number
@@ -85,6 +93,7 @@ export interface SimulationParams {
   reservoir: ReservoirParams
   surfaceTension: SurfaceTensionParams
   capillaryFringe: CapillaryFringeParams
+  evaporationRings: EvaporationRingParams
   pigmentCoefficients?: PigmentCoefficients
 }
 
@@ -134,6 +143,7 @@ export type MaterialMap = {
   absorbPigment: THREE.RawShaderMaterial
   absorbWet: THREE.RawShaderMaterial
   absorbSettled: THREE.RawShaderMaterial
+  evaporationRings: THREE.RawShaderMaterial
   diffuseWet: DiffuseWetMaterial
   composite: THREE.RawShaderMaterial
   divergence: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- add a coffee-ring redistribution shader and wire it into the simulation pipeline with configurable defaults
- expose evaporation ring controls in the UI and document the new behaviour and parameters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd1189e7988326842c90b6a7e28c6d