### PR TITLE
Add debug visualization modes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Leva, button, useControls } from 'leva'
 import WatercolorViewport, { type ViewportBrush } from '@/components/watercolor/WatercolorViewport'
+import { DEBUG_VIEW_LABELS, DEBUG_VIEW_OPTIONS, type DebugView } from '@/components/watercolor/debugViews'
 import * as THREE from 'three'
 import {
   DEFAULT_ABSORB_EXPONENT,
@@ -383,6 +384,14 @@ export default function Home() {
     },
   })
 
+  const debugControls = useControls('Debug Visualization', {
+    debugView: {
+      label: 'Channel',
+      value: 'composite' as DebugView,
+      options: DEBUG_VIEW_OPTIONS,
+    },
+  })
+
   useControls('Actions', {
     clear: button(() => setClearSignal((value) => value + 1)),
   })
@@ -459,6 +468,7 @@ export default function Home() {
     granulation: boolean
     paperTextureStrength: number
   }
+  const debugView = debugControls.debugView as DebugView
   const {
     enabled: ringEnabled,
     strength: ringStrength,
@@ -682,9 +692,16 @@ export default function Home() {
             brush={brush}
             size={SIM_SIZE}
             clearSignal={clearSignal}
+            debugView={debugView}
           />
-          <div className='pointer-events-none absolute bottom-4 left-4 text-[10px] uppercase tracking-wide text-slate-400 sm:text-xs'>
-            Resolution {SIM_SIZE}x{SIM_SIZE}
+          <div className='pointer-events-none absolute bottom-4 left-4 flex flex-col gap-1 text-[10px] tracking-wide text-slate-400 sm:text-xs'>
+            <span className='uppercase'>Resolution {SIM_SIZE}x{SIM_SIZE}</span>
+            {debugView !== 'composite' && (
+              <span className='inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-2 py-1 text-[9px] font-semibold text-slate-200 shadow-sm sm:text-[10px]'>
+                <span className='uppercase text-slate-400'>Debug</span>
+                <span className='normal-case text-slate-100'>{DEBUG_VIEW_LABELS[debugView]}</span>
+              </span>
+            )}
           </div>
           {brush.type !== 'water' && pigmentIndex >= 0 && (
             <div className='pointer-events-none absolute right-4 top-4 flex items-center gap-2 rounded-full border border-slate-500/60 bg-slate-900/80 px-3 py-1 text-xs text-slate-200 shadow-lg sm:text-sm'>

--- a/components/watercolor/WatercolorScene.tsx
+++ b/components/watercolor/WatercolorScene.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { OrthographicCamera } from '@react-three/drei'
 import * as THREE from 'three'
 import WatercolorSimulation, { type SimulationParams } from '@/lib/watercolor/WatercolorSimulation'
+import { type DebugView } from './debugViews'
 
 // Fullscreen quad shader that forwards UVs to the fragment stage.
 const DISPLAY_VERTEX = `
@@ -17,16 +18,110 @@ void main() {
 }
 `
 
-// Sample the simulation texture and present a gamma-corrected color.
+const DEBUG_VIEW_MODE: Record<DebugView, number> = {
+  composite: 0,
+  waterHeight: 1,
+  velocity: 2,
+  dissolvedPigment: 3,
+  depositedPigment: 4,
+  wetness: 5,
+  binder: 6,
+  granulation: 7,
+  paperHeight: 8,
+  paperSizing: 9,
+  paperFibers: 10,
+}
+
+// Sample different simulation buffers based on the active debug view.
 const DISPLAY_FRAGMENT = `
 precision highp float;
 in vec2 vUv;
-uniform sampler2D uTexture;
+uniform sampler2D uComposite;
+uniform sampler2D uHeight;
+uniform sampler2D uVelocity;
+uniform sampler2D uPigment;
+uniform sampler2D uDeposits;
+uniform sampler2D uWetness;
+uniform sampler2D uBinder;
+uniform sampler2D uGranulation;
+uniform sampler2D uPaperHeight;
+uniform sampler2D uPaperSizing;
+uniform sampler2D uPaperFiber;
+uniform int uMode;
 out vec4 fragColor;
+
+const float PI = 3.141592653589793;
+
+vec3 applyGamma(vec3 color) {
+  return pow(clamp(color, vec3(0.0), vec3(1.0)), vec3(1.0 / 2.2));
+}
+
+vec3 hsv2rgb(vec3 c) {
+  vec3 rgb = clamp(abs(mod(c.x * 6.0 + vec3(0.0, 4.0, 2.0), 6.0) - 3.0) - 1.0, 0.0, 1.0);
+  rgb = rgb * rgb * (3.0 - 2.0 * rgb);
+  return c.z * mix(vec3(1.0), rgb, c.y);
+}
+
+vec3 renderVelocity(vec2 vel) {
+  float mag = length(vel);
+  float intensity = 1.0 - exp(-mag * 4.0);
+  float angle = atan(vel.y, vel.x);
+  float hue = fract(angle / (2.0 * PI) + 0.5);
+  return hsv2rgb(vec3(hue, 0.75, intensity));
+}
+
+vec3 renderScalar(float value) {
+  float tone = 1.0 - exp(-max(value, 0.0));
+  return vec3(tone);
+}
+
 void main() {
-  vec3 col = texture(uTexture, vUv).rgb;
-  vec3 gamma = pow(clamp(col, vec3(0.0), vec3(1.0)), vec3(1.0/2.2));
-  fragColor = vec4(gamma, 1.0);
+  vec3 color = vec3(0.0);
+
+  if (uMode == 0) {
+    color = applyGamma(texture(uComposite, vUv).rgb);
+  } else if (uMode == 1) {
+    float height = texture(uHeight, vUv).r;
+    color = renderScalar(height * 8.0);
+  } else if (uMode == 2) {
+    vec2 vel = texture(uVelocity, vUv).rg;
+    color = renderVelocity(vel);
+  } else if (uMode == 3) {
+    vec3 pigment = texture(uPigment, vUv).rgb;
+    color = applyGamma(pigment * 2.0);
+  } else if (uMode == 4) {
+    vec3 deposits = texture(uDeposits, vUv).rgb;
+    color = applyGamma(deposits * 1.5);
+  } else if (uMode == 5) {
+    float wet = texture(uWetness, vUv).r;
+    color = renderScalar(wet * 5.0);
+  } else if (uMode == 6) {
+    float binder = texture(uBinder, vUv).r;
+    float tone = 1.0 - exp(-max(binder, 0.0) * 4.0);
+    color = vec3(tone, tone * 0.6, tone * 0.2);
+  } else if (uMode == 7) {
+    vec3 granulation = texture(uGranulation, vUv).rgb;
+    color = applyGamma(granulation * 2.5);
+  } else if (uMode == 8) {
+    float paperHeight = texture(uPaperHeight, vUv).r;
+    color = vec3(paperHeight);
+  } else if (uMode == 9) {
+    float sizing = texture(uPaperSizing, vUv).r;
+    color = vec3(sizing);
+  } else if (uMode == 10) {
+    vec4 fiber = texture(uPaperFiber, vUv);
+    vec2 dir = fiber.xy;
+    float len = max(length(dir), 1e-4);
+    dir /= len;
+    float angle = atan(dir.y, dir.x);
+    float hue = fract(angle / (2.0 * PI) + 0.5);
+    float anisotropy = clamp((fiber.z - fiber.w) * 0.5 + 0.5, 0.0, 1.0);
+    color = hsv2rgb(vec3(hue, 0.6, anisotropy));
+  } else {
+    color = applyGamma(texture(uComposite, vUv).rgb);
+  }
+
+  fragColor = vec4(color, 1.0);
 }
 `
 
@@ -35,17 +130,35 @@ type WatercolorSceneProps = {
   size?: number
   clearSignal: number
   onReady?: (sim: WatercolorSimulation | null) => void
+  debugView?: DebugView
 }
 
 // WatercolorScene drives the GPU simulation and blits the result onto a fullscreen quad.
-const WatercolorScene = ({ params, size = 512, clearSignal, onReady }: WatercolorSceneProps) => {
+const WatercolorScene = ({
+  params,
+  size = 512,
+  clearSignal,
+  onReady,
+  debugView = 'composite',
+}: WatercolorSceneProps) => {
   const { gl } = useThree()
   const simRef = useRef<WatercolorSimulation | null>(null)
   const paramsRef = useRef(params)
   const accumulatorRef = useRef(0)
   // Lazily store uniforms so the shader can be updated without reconstructing it.
   const uniforms = useMemo(() => ({
-    uTexture: { value: null as THREE.Texture | null },
+    uComposite: { value: null as THREE.Texture | null },
+    uHeight: { value: null as THREE.Texture | null },
+    uVelocity: { value: null as THREE.Texture | null },
+    uPigment: { value: null as THREE.Texture | null },
+    uDeposits: { value: null as THREE.Texture | null },
+    uWetness: { value: null as THREE.Texture | null },
+    uBinder: { value: null as THREE.Texture | null },
+    uGranulation: { value: null as THREE.Texture | null },
+    uPaperHeight: { value: null as THREE.Texture | null },
+    uPaperSizing: { value: null as THREE.Texture | null },
+    uPaperFiber: { value: null as THREE.Texture | null },
+    uMode: { value: 0 },
   }), [])
 
   // RawShaderMaterial lets us render the simulation output texture directly.
@@ -68,19 +181,46 @@ const WatercolorScene = ({ params, size = 512, clearSignal, onReady }: Watercolo
   }, [params])
 
   // Create the simulation instance once the WebGL renderer is ready.
+  const applyUniformTextures = useCallback(
+    (sim: WatercolorSimulation) => {
+      uniforms.uComposite.value = sim.outputTexture
+      uniforms.uHeight.value = sim.waterHeightTexture
+      uniforms.uVelocity.value = sim.velocityTexture
+      uniforms.uPigment.value = sim.dissolvedPigmentTexture
+      uniforms.uDeposits.value = sim.depositedPigmentTexture
+      uniforms.uWetness.value = sim.wetnessTexture
+      uniforms.uBinder.value = sim.binderTexture
+      uniforms.uGranulation.value = sim.settledPigmentTexture
+      uniforms.uPaperHeight.value = sim.paperHeightTexture
+      uniforms.uPaperSizing.value = sim.paperSizingTexture
+      uniforms.uPaperFiber.value = sim.paperFiberTexture
+    },
+    [uniforms],
+  )
+
   useEffect(() => {
     const sim = new WatercolorSimulation(gl, size)
     simRef.current = sim
-    uniforms.uTexture.value = sim.outputTexture
+    applyUniformTextures(sim)
     onReady?.(sim)
 
     return () => {
       onReady?.(null)
-      uniforms.uTexture.value = null
+      uniforms.uComposite.value = null
+      uniforms.uHeight.value = null
+      uniforms.uVelocity.value = null
+      uniforms.uPigment.value = null
+      uniforms.uDeposits.value = null
+      uniforms.uWetness.value = null
+      uniforms.uBinder.value = null
+      uniforms.uGranulation.value = null
+      uniforms.uPaperHeight.value = null
+      uniforms.uPaperSizing.value = null
+      uniforms.uPaperFiber.value = null
       sim.dispose()
       simRef.current = null
     }
-  }, [gl, size, onReady, uniforms])
+  }, [gl, size, onReady, applyUniformTextures, uniforms])
 
   useEffect(() => () => material.dispose(), [material])
 
@@ -89,6 +229,10 @@ const WatercolorScene = ({ params, size = 512, clearSignal, onReady }: Watercolo
     if (clearSignal === 0) return
     simRef.current?.reset()
   }, [clearSignal])
+
+  useEffect(() => {
+    uniforms.uMode.value = DEBUG_VIEW_MODE[debugView] ?? 0
+  }, [debugView, uniforms])
 
   // Advance the simulation with a fixed timestep for numerical stability.
   useFrame((_, delta) => {
@@ -101,6 +245,8 @@ const WatercolorScene = ({ params, size = 512, clearSignal, onReady }: Watercolo
       sim.step(paramsRef.current, fixedDt)
       accumulatorRef.current -= fixedDt
     }
+
+    applyUniformTextures(sim)
   })
 
   return (

--- a/components/watercolor/WatercolorViewport.tsx
+++ b/components/watercolor/WatercolorViewport.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import View from '@/components/canvas/View'
 import WatercolorScene from './WatercolorScene'
 import WatercolorSimulation, { type BrushType, type SimulationParams } from '@/lib/watercolor/WatercolorSimulation'
+import { type DebugView } from './debugViews'
 import type { Texture } from 'three'
 
 type BrushMaskSettings = {
@@ -44,6 +45,7 @@ type WatercolorViewportProps = {
   clearSignal: number
   className?: string
   onSimulationReady?: (sim: WatercolorSimulation | null) => void
+  debugView?: DebugView
 }
 
 // Clamp to [0, 1] for normalized UV coordinates.
@@ -84,6 +86,7 @@ const WatercolorViewport = ({
   clearSignal,
   className,
   onSimulationReady,
+  debugView = 'composite',
 }: WatercolorViewportProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const simRef = useRef<WatercolorSimulation | null>(null)
@@ -490,7 +493,13 @@ const WatercolorViewport = ({
 
   return (
     <View ref={containerRef} className={className}>
-      <WatercolorScene params={params} size={size} clearSignal={clearSignal} onReady={handleReady} />
+      <WatercolorScene
+        params={params}
+        size={size}
+        clearSignal={clearSignal}
+        onReady={handleReady}
+        debugView={debugView}
+      />
     </View>
   )
 }

--- a/components/watercolor/debugViews.ts
+++ b/components/watercolor/debugViews.ts
@@ -1,0 +1,30 @@
+export type DebugView =
+  | 'composite'
+  | 'waterHeight'
+  | 'velocity'
+  | 'dissolvedPigment'
+  | 'depositedPigment'
+  | 'wetness'
+  | 'binder'
+  | 'granulation'
+  | 'paperHeight'
+  | 'paperSizing'
+  | 'paperFibers'
+
+export const DEBUG_VIEW_LABELS: Record<DebugView, string> = {
+  composite: 'Final Composite',
+  waterHeight: 'Water Height',
+  velocity: 'Fluid Velocity',
+  dissolvedPigment: 'Dissolved Pigment',
+  depositedPigment: 'Deposited Pigment',
+  wetness: 'Paper Wetness',
+  binder: 'Binder Density',
+  granulation: 'Granulation Reservoir',
+  paperHeight: 'Paper Height Map',
+  paperSizing: 'Sizing Variation',
+  paperFibers: 'Fiber Field',
+}
+
+export const DEBUG_VIEW_OPTIONS = Object.fromEntries(
+  Object.entries(DEBUG_VIEW_LABELS).map(([value, label]) => [label, value as DebugView]),
+) as Record<string, DebugView>

--- a/docs/components.md
+++ b/docs/components.md
@@ -44,6 +44,7 @@ The components directory is divided into canvas primitives, DOM layout, cross-tr
   - size: square resolution (defaults to 512) for the internal render targets.
   - clearSignal: bump this number to reset the simulation state.
   - onReady(sim): callback fired when a WatercolorSimulation instance is created or disposed; receives null on teardown.
+  - debugView: selects which internal render target is visualised (final composite, water height, velocity, pigment channels, paper maps, etc.).
 - Exposes the simulation output through an orthographic camera, so you can nest it inside any View driven layout.
 
 ### WatercolorViewport (components/watercolor/WatercolorViewport.tsx)
@@ -55,5 +56,6 @@ The components directory is divided into canvas primitives, DOM layout, cross-tr
   - clearSignal: increment to wipe the simulation.
   - className: optional CSS class applied to the container div.
   - onSimulationReady(sim): receives the WatercolorSimulation instance when it is ready for imperative control.
+  - debugView: forwards the selected debug channel down to WatercolorScene for visual inspection.
 - Attaches pointer listeners directly to the DOM container to track drawing state, convert pointer coordinates to UV space, and schedule splat calls as the cursor moves.
 - Manages a per stroke reservoir so water and pigment naturally deplete and alter the stroke radius and flow over time.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -147,6 +147,7 @@ Leva panels in the demo map directly to `SimulationParams` fields:
 - **Brush Reservoir** – Water/pigment capacities and per-stamp consumption rates.
 - **Pigment Separation** – RGB diffusion/settling overrides and per-pigment presets.
 - **Simulation Features** – Toggles for state-dependent absorption, paper-texture-driven granulation, and rewetting behaviour.
+- **Debug Visualization** – Switch between the final composite and internal buffers (height, velocity, pigment, wetness, binder, paper maps) to inspect solver state.
 
 ## References
 

--- a/lib/watercolor/WatercolorSimulation.ts
+++ b/lib/watercolor/WatercolorSimulation.ts
@@ -121,6 +121,42 @@ export default class WatercolorSimulation {
     return this.paperHeightMap
   }
 
+  get waterHeightTexture(): THREE.Texture {
+    return this.targets.H.read.texture
+  }
+
+  get velocityTexture(): THREE.Texture {
+    return this.targets.UV.read.texture
+  }
+
+  get dissolvedPigmentTexture(): THREE.Texture {
+    return this.targets.C.read.texture
+  }
+
+  get depositedPigmentTexture(): THREE.Texture {
+    return this.targets.DEP.read.texture
+  }
+
+  get wetnessTexture(): THREE.Texture {
+    return this.targets.W.read.texture
+  }
+
+  get binderTexture(): THREE.Texture {
+    return this.targets.B.read.texture
+  }
+
+  get settledPigmentTexture(): THREE.Texture {
+    return this.targets.S.read.texture
+  }
+
+  get paperSizingTexture(): THREE.DataTexture {
+    return this.sizingMap
+  }
+
+  get paperFiberTexture(): THREE.DataTexture {
+    return this.fiberTexture
+  }
+
   // Inject water or pigment into the simulation at a given position.
   splat(brush: BrushSettings) {
     const {


### PR DESCRIPTION
## Summary
- add a Leva panel to switch between the composite image and internal simulation buffers for debugging
- expose simulation render targets and update WatercolorScene to render selected debug channels
- document the new debug view props and channel options for future reference

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd1651365c8326bd821e1f8b4a4a79