### PR TITLE
Switch watercolor splats to mask-driven stroke pipeline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,7 +312,6 @@ export default function Home() {
     pigmentCapacity: { label: 'Pigment Charge', value: 11, min: 1, max: 20, step: 0.05 },
     waterConsumption: { label: 'Water Consumption', value: 0.28, min: 0.01, max: 1, step: 0.01 },
     pigmentConsumption: { label: 'Pigment Consumption', value: 0.22, min: 0.01, max: 1, step: 0.01 },
-    stampSpacing: { label: 'Stamp Spacing', value: 0.015, min: 0.001, max: 0.05, step: 0.001 },
   })
 
   const featureControls = useControls('Features', {
@@ -493,12 +492,11 @@ export default function Home() {
     threshold: number
     noiseScale: number
   }
-  const { waterCapacityWater, pigmentCapacity, waterConsumption, pigmentConsumption, stampSpacing } = reservoirControls as {
+  const { waterCapacityWater, pigmentCapacity, waterConsumption, pigmentConsumption } = reservoirControls as {
     waterCapacityWater: number;
     pigmentCapacity: number;
     waterConsumption: number;
     pigmentConsumption: number;
-    stampSpacing: number;
   }
   const pigmentIndex = tool === 'water' ? -1 : parseInt(tool.slice(-1), 10)
 
@@ -636,7 +634,6 @@ export default function Home() {
       pigmentCapacity,
       waterConsumption,
       pigmentConsumption,
-      stampSpacing,
     },
   }), [
     grav,
@@ -677,7 +674,6 @@ export default function Home() {
     pigmentCapacity,
     waterConsumption,
     pigmentConsumption,
-    stampSpacing,
   ])
 
   return (

--- a/components/watercolor/WatercolorViewport.tsx
+++ b/components/watercolor/WatercolorViewport.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import View from '@/components/canvas/View'
 import WatercolorScene from './WatercolorScene'
 import WatercolorSimulation, { type BrushType, type SimulationParams } from '@/lib/watercolor/WatercolorSimulation'
+import StrokeMaskBuilder, { type MaskStamp } from '@/lib/watercolor/maskBuilder'
 import { type DebugView } from './debugViews'
 import type { Texture } from 'three'
 
@@ -72,10 +73,30 @@ type Reservoir = {
   initialPigment: number
   water: number
   pigment: number
-  lastStamp: [number, number] | null
   lastPos: [number, number] | null
-  distanceSinceStamp: number
   lastAngle: number
+}
+
+type BrushStamp = {
+  mask: MaskStamp
+  flow: number
+  dryness: number
+  dryThreshold?: number
+  lowSolvent: number
+  color: [number, number, number]
+  velocity: [number, number]
+}
+
+type StrokeState = {
+  stamps: BrushStamp[]
+  baseFlow: number
+  type: BrushType
+  binderBoost: number
+  pigmentBoost: number
+  depositBoost?: number
+  maskTexture: Texture
+  lastRadius: number
+  pasteMode: boolean
 }
 
 // WatercolorViewport hosts the interactive canvas and bridges pointer input to the simulation.
@@ -93,15 +114,18 @@ const WatercolorViewport = ({
   const brushRef = useRef(brush)
   const paintingRef = useRef(false)
   const reservoirRef = useRef<Reservoir | null>(null)
+  const maskBuilderRef = useRef<StrokeMaskBuilder | null>(null)
+  const strokeRef = useRef<StrokeState | null>(null)
 
   useEffect(() => {
     brushRef.current = brush
     reservoirRef.current = null
+    strokeRef.current = null
   }, [brush])
 
-  // Notify upstream code when the GPU simulation becomes available.
   const handleReady = useCallback((sim: WatercolorSimulation | null) => {
     simRef.current = sim
+    maskBuilderRef.current = sim?.strokeMaskBuilder ?? null
     onSimulationReady?.(sim)
   }, [onSimulationReady])
 
@@ -111,13 +135,14 @@ const WatercolorViewport = ({
 
     const reservoirParams = params.reservoir
     reservoirRef.current = null
+    strokeRef.current = null
+
     const {
       waterCapacityWater,
       waterCapacityPigment,
       pigmentCapacity,
       waterConsumption,
       pigmentConsumption,
-      stampSpacing,
     } = reservoirParams
 
     const previousTouchAction = el.style.touchAction
@@ -125,7 +150,6 @@ const WatercolorViewport = ({
     el.style.touchAction = 'none'
     el.style.cursor = 'crosshair'
 
-    // Create a fresh reservoir so water/pigment depletes realistically per stroke.
     const createReservoir = (type: BrushType): Reservoir => {
       if (type === 'water') {
         return {
@@ -133,9 +157,7 @@ const WatercolorViewport = ({
           initialPigment: 0,
           water: waterCapacityWater,
           pigment: 0,
-          lastStamp: null,
           lastPos: null,
-          distanceSinceStamp: stampSpacing,
           lastAngle: 0,
         }
       }
@@ -145,14 +167,11 @@ const WatercolorViewport = ({
         initialPigment: pigmentCapacity,
         water: waterCapacityPigment,
         pigment: pigmentCapacity,
-        lastStamp: null,
         lastPos: null,
-        distanceSinceStamp: stampSpacing,
         lastAngle: 0,
       }
     }
 
-    // Convert pointer events to simulation-space UV coordinates.
     const getUV = (event: PointerEvent): [number, number] => {
       const rect = el.getBoundingClientRect()
       const u = (event.clientX - rect.left) / rect.width
@@ -160,21 +179,343 @@ const WatercolorViewport = ({
       return [clamp01(u), clamp01(v)]
     }
 
-    const emitSpatterDroplets = (
-      target: [number, number],
-      brushState: ViewportBrush,
-      reservoir: Reservoir,
-      heading: number,
-    ) => {
-      const simInstance = simRef.current
-      const spatter = brushState.spatter
-      if (!simInstance || !spatter) {
+    const summarizeStamps = (stroke: StrokeState) => {
+      const baseFlow = Math.max(stroke.baseFlow, 1e-5)
+      let totalWeight = 0
+      let flowRatioSum = 0
+      let strengthSum = 0
+      let drynessSum = 0
+      let lowSolventSum = 0
+      let dryThresholdSum = 0
+      let dryThresholdWeight = 0
+      const colorSum: [number, number, number] = [0, 0, 0]
+      let colorWeight = 0
+      let velocitySumX = 0
+      let velocitySumY = 0
+      let velocityWeight = 0
+
+      stroke.stamps.forEach((stamp) => {
+        const weight = Math.max(stamp.mask.radius * stamp.mask.radius, 1e-5)
+        totalWeight += weight
+        const flowRatio = baseFlow > 1e-5 ? stamp.flow / baseFlow : 1
+        flowRatioSum += flowRatio * weight
+        strengthSum += stamp.mask.strength * weight
+        drynessSum += stamp.dryness * weight
+        lowSolventSum += stamp.lowSolvent * weight
+        colorSum[0] += stamp.color[0] * weight
+        colorSum[1] += stamp.color[1] * weight
+        colorSum[2] += stamp.color[2] * weight
+        colorWeight += weight
+        const velWeight = Math.max(stamp.flow, 0) * weight
+        velocitySumX += stamp.velocity[0] * velWeight
+        velocitySumY += stamp.velocity[1] * velWeight
+        velocityWeight += velWeight
+        if (typeof stamp.dryThreshold === 'number') {
+          dryThresholdSum += stamp.dryThreshold * weight
+          dryThresholdWeight += weight
+        }
+      })
+
+      const flowScale = totalWeight > 0 ? flowRatioSum / totalWeight : 1
+      const maskStrength = totalWeight > 0 ? strengthSum / totalWeight : 1
+      const dryness = totalWeight > 0 ? drynessSum / totalWeight : 0
+      const lowSolvent = totalWeight > 0 ? lowSolventSum / totalWeight : 0
+      const dryThreshold =
+        dryThresholdWeight > 0 ? dryThresholdSum / dryThresholdWeight : undefined
+      const color: [number, number, number] =
+        colorWeight > 0
+          ? [
+              colorSum[0] / colorWeight,
+              colorSum[1] / colorWeight,
+              colorSum[2] / colorWeight,
+            ]
+          : [0, 0, 0]
+      const velocityVecX = velocityWeight > 0 ? velocitySumX / velocityWeight : 0
+      const velocityVecY = velocityWeight > 0 ? velocitySumY / velocityWeight : 0
+      const velocityStrength = Math.hypot(velocityVecX, velocityVecY)
+      const velocity: [number, number] =
+        velocityStrength > 1e-5
+          ? [velocityVecX / velocityStrength, velocityVecY / velocityStrength]
+          : [0, 0]
+
+      return {
+        flowScale,
+        maskStrength,
+        dryness,
+        dryThreshold,
+        lowSolvent,
+        color,
+        velocity,
+        velocityStrength,
+      }
+    }
+
+    const flushStroke = (final = false) => {
+      const stroke = strokeRef.current
+      if (!stroke) {
+        return
+      }
+      const sim = simRef.current
+      const builder = maskBuilderRef.current
+      if (!sim || !builder) {
+        stroke.stamps = []
+        stroke.lastRadius = 0
+        if (final) {
+          strokeRef.current = null
+        }
+        return
+      }
+      if (stroke.stamps.length === 0) {
+        if (final) {
+          strokeRef.current = null
+        }
+        return
+      }
+
+      const { texture } = builder.build(
+        stroke.stamps.map((stamp) => stamp.mask),
+        stroke.maskTexture,
+      )
+      const summary = summarizeStamps(stroke)
+
+      sim.splat({
+        flow: stroke.baseFlow,
+        type: stroke.type,
+        color: summary.color,
+        dryness: summary.dryness,
+        dryThreshold: summary.dryThreshold,
+        lowSolvent: summary.lowSolvent,
+        binderBoost: stroke.binderBoost,
+        pigmentBoost: stroke.pigmentBoost,
+        depositBoost: stroke.depositBoost,
+        mask: {
+          kind: 'stroke',
+          texture,
+          strength: summary.maskStrength,
+          flowScale: summary.flowScale,
+          velocity: summary.velocity,
+          velocityStrength: summary.velocityStrength,
+        },
+      })
+
+      stroke.stamps = []
+      stroke.lastRadius = 0
+      if (final) {
+        strokeRef.current = null
+      }
+    }
+
+    const addStamp = (uv: [number, number], dir: [number, number]) => {
+      const stroke = strokeRef.current
+      const reservoir = reservoirRef.current
+      const brushState = brushRef.current
+      if (!stroke || !reservoir || !brushState || brushState.type === 'spatter') {
         return false
+      }
+      if (!brushState.mask.texture) {
+        return false
+      }
+
+      const waterRatio =
+        reservoir.initialWater > 0 ? reservoir.water / reservoir.initialWater : 0
+      const pigmentRatio =
+        reservoir.initialPigment > 0
+          ? reservoir.pigment / reservoir.initialPigment
+          : 0
+
+      if (brushState.type === 'water' && waterRatio <= 0.01) {
+        return false
+      }
+      if (
+        brushState.type !== 'water' &&
+        (waterRatio <= 0.01 || pigmentRatio <= 0.01)
+      ) {
+        return false
+      }
+
+      const baseFlow = brushState.flow
+      const wetness = clamp01(waterRatio)
+      const radiusScale = 0.55 + 0.45 * wetness
+      const scaledRadiusPx = Math.max(brushState.radius * radiusScale, 1)
+      const radiusNorm = scaledRadiusPx / size
+      const flowScale = 0.25 + 0.75 * wetness
+      const actualFlow = baseFlow * flowScale
+
+      const pasteActive = stroke.pasteMode
+      const baseDryness =
+        brushState.type === 'water' ? 0 : clamp01(1 - waterRatio)
+      const lowSolvent = 0
+      const dryness = pasteActive ? Math.max(baseDryness, 0.92) : baseDryness
+      const dryThreshold = lowSolvent > 0 ? 0.82 : undefined
+
+      let dirX = dir[0]
+      let dirY = dir[1]
+      const length = Math.hypot(dirX, dirY)
+      let heading = reservoir.lastAngle
+      if (length > 1e-5) {
+        dirX /= length
+        dirY /= length
+        heading = Math.atan2(dirY, dirX)
+      } else {
+        dirX = Math.cos(heading)
+        dirY = Math.sin(heading)
+      }
+      reservoir.lastAngle = heading
+
+      const maskSettings = brushState.mask
+      const pressureFactor = 1 + (maskSettings.pressureScale ?? 0) * (1 - wetness)
+      const maskScale: [number, number] = [
+        maskSettings.scale[0] * pressureFactor,
+        maskSettings.scale[1] * pressureFactor,
+      ]
+      const jitter = (Math.random() - 0.5) * (maskSettings.rotationJitter ?? 0)
+      const rotation = heading + jitter
+      const maskStrength = Math.min(
+        1,
+        maskSettings.strength * (0.65 + 0.35 * (1 - wetness)),
+      )
+
+      const color: [number, number, number] =
+        brushState.type === 'pigment'
+          ? [
+              brushState.color[0] * pigmentRatio,
+              brushState.color[1] * pigmentRatio,
+              brushState.color[2] * pigmentRatio,
+            ]
+          : [0, 0, 0]
+
+      stroke.stamps.push({
+        mask: {
+          center: uv,
+          radius: radiusNorm,
+          rotation,
+          scale: maskScale,
+          strength: maskStrength,
+        },
+        flow: actualFlow,
+        dryness,
+        dryThreshold,
+        lowSolvent,
+        color,
+        velocity: [dirX * actualFlow, dirY * actualFlow],
+      })
+      stroke.lastRadius = radiusNorm
+      reservoir.lastPos = uv
+
+      const areaFactor = radiusNorm * radiusNorm
+      const flowContribution = actualFlow * 0.5
+      reservoir.water = Math.max(
+        0,
+        reservoir.water - waterConsumption * (areaFactor + flowContribution),
+      )
+      if (brushState.type === 'pigment') {
+        reservoir.pigment = Math.max(
+          0,
+          reservoir.pigment - pigmentConsumption * (areaFactor + flowContribution),
+        )
+      }
+
+      if (stroke.stamps.length >= 48) {
+        flushStroke(false)
+      }
+
+      return true
+    }
+
+    const addSegment = (uv: [number, number]) => {
+      const reservoir = reservoirRef.current
+      const stroke = strokeRef.current
+      const brushState = brushRef.current
+      if (!reservoir || !stroke || !brushState || brushState.type === 'spatter') {
+        return
+      }
+
+      const prev = reservoir.lastPos
+      if (!prev) {
+        reservoir.lastPos = uv
+        addStamp(uv, [0, 0])
+        return
+      }
+
+      const dx = uv[0] - prev[0]
+      const dy = uv[1] - prev[1]
+      const dist = Math.hypot(dx, dy)
+      if (dist < 1e-5) {
+        return
+      }
+
+      const dir: [number, number] = [dx / dist, dy / dist]
+      const spacingBase = Math.max(
+        stroke.lastRadius || brushState.radius / size,
+        0.0015,
+      )
+      const spacing = Math.max(spacingBase * 0.75, 0.001)
+      const steps = Math.max(1, Math.ceil(dist / spacing))
+
+      for (let i = 1; i <= steps; i += 1) {
+        const t = i / steps
+        const point: [number, number] = [prev[0] + dx * t, prev[1] + dy * t]
+        if (!addStamp(point, dir)) {
+          return
+        }
+      }
+    }
+
+    const beginStroke = (uv: [number, number]) => {
+      if (!maskBuilderRef.current) {
+        return
+      }
+      const brushState = brushRef.current
+      if (!brushState || brushState.type === 'spatter') {
+        return
+      }
+      const reservoir = createReservoir(brushState.type)
+      reservoir.lastPos = uv
+      reservoir.lastAngle = 0
+      reservoirRef.current = reservoir
+
+      const maskTexture = brushState.mask.texture
+      if (!maskTexture) {
+        return
+      }
+
+      strokeRef.current = {
+        stamps: [],
+        baseFlow: Math.max(brushState.flow, 0),
+        type: brushState.type,
+        binderBoost: brushState.binderBoost ?? 1,
+        pigmentBoost: brushState.pigmentBoost ?? 1,
+        depositBoost: brushState.pigmentBoost ?? 1,
+        maskTexture,
+        lastRadius: 0,
+        pasteMode: brushState.type === 'pigment' && !!brushState.pasteMode,
+      }
+
+      addStamp(uv, [0, 0])
+    }
+
+    const emitSpatter = (target: [number, number], heading: number) => {
+      const simInstance = simRef.current
+      const builder = maskBuilderRef.current
+      const brushState = brushRef.current
+      const reservoir = reservoirRef.current
+      if (
+        !simInstance ||
+        !builder ||
+        !brushState ||
+        brushState.type !== 'spatter' ||
+        !reservoir
+      ) {
+        return
+      }
+      const spatter = brushState.spatter
+      if (!spatter || !brushState.mask.texture) {
+        return
       }
 
       const dropletCount = Math.max(1, Math.round(spatter.dropletCount))
       if (dropletCount <= 0) {
-        return false
+        return
       }
 
       const minSize = Math.max(0.01, Math.min(spatter.minSize, spatter.maxSize))
@@ -191,13 +532,13 @@ const WatercolorViewport = ({
       const baseColor = brushState.color
       const baseRadius = Math.max(brushState.radius, 1)
 
-      let emitted = 0
-
       for (let i = 0; i < dropletCount; i += 1) {
         const waterRatio =
           reservoir.initialWater > 0 ? reservoir.water / reservoir.initialWater : 0
         const pigmentRatio =
-          reservoir.initialPigment > 0 ? reservoir.pigment / reservoir.initialPigment : 0
+          reservoir.initialPigment > 0
+            ? reservoir.pigment / reservoir.initialPigment
+            : 0
         if (waterRatio <= 0.01 || pigmentRatio <= 0.01) {
           break
         }
@@ -242,9 +583,20 @@ const WatercolorViewport = ({
 
         const depositBoost = Math.max(pigmentBoost, 1 + sizeNorm * 0.8)
 
+        const { texture } = builder.build(
+          [
+            {
+              center,
+              radius: dropletRadius,
+              rotation: 0,
+              scale: [1, 1],
+              strength: brushState.mask.strength,
+            },
+          ],
+          brushState.mask.texture,
+        )
+
         simInstance.splat({
-          center,
-          radius: dropletRadius,
           flow: dropletFlow,
           type: 'spatter',
           color,
@@ -254,6 +606,14 @@ const WatercolorViewport = ({
           binderBoost,
           pigmentBoost,
           depositBoost,
+          mask: {
+            kind: 'droplet',
+            texture,
+            strength: brushState.mask.strength,
+            flowScale: 1,
+            velocity: [Math.cos(dirAngle), Math.sin(dirAngle)],
+            velocityStrength: dropletFlow * 0.7,
+          },
         })
 
         const areaFactor = dropletRadius * dropletRadius
@@ -266,204 +626,69 @@ const WatercolorViewport = ({
           0,
           reservoir.pigment - pigmentConsumption * (areaFactor + flowContribution),
         )
-        emitted += 1
       }
 
-      if (emitted > 0) {
-        reservoir.lastStamp = target
-      }
-
-      return emitted > 0
+      reservoir.lastPos = target
+      reservoir.lastAngle = heading
     }
 
-    // Stamp pigment/water into the simulation with adaptive spacing and depletion.
-    const splatAt = (uv: [number, number], forceStamp = false) => {
-      const sim = simRef.current
-      const reservoir = reservoirRef.current
-      if (!sim || !reservoir) return
-
-      const prevPos = reservoir.lastPos
-      const prevDistance = forceStamp ? 0 : reservoir.distanceSinceStamp
-      const brushState = brushRef.current
-
-      let dx = 0
-      let dy = 0
-      let segmentLength = 0
-      if (prevPos) {
-        dx = uv[0] - prevPos[0]
-        dy = uv[1] - prevPos[1]
-        segmentLength = Math.hypot(dx, dy)
-      }
-      reservoir.lastPos = uv
-
-      const stampOnce = (target: [number, number]) => {
-        const waterRatio =
-          reservoir.initialWater > 0 ? reservoir.water / reservoir.initialWater : 0
-        const pigmentRatio =
-          reservoir.initialPigment > 0 ? reservoir.pigment / reservoir.initialPigment : 0
-
-        let heading = segmentLength > 1e-5 ? Math.atan2(dy, dx) : reservoir.lastAngle
-        if (!Number.isFinite(heading)) {
-          heading = 0
-        }
-        reservoir.lastAngle = heading
-
-        if (brushState.type === 'spatter') {
-          if (waterRatio <= 0.01 || pigmentRatio <= 0.01) {
-            return false
-          }
-          return emitSpatterDroplets(target, brushState, reservoir, heading)
-        }
-
-        if (brushState.type === 'water' && waterRatio <= 0.01) {
-          return false
-        }
-        if (brushState.type !== 'water' && (waterRatio <= 0.01 || pigmentRatio <= 0.01)) {
-          return false
-        }
-
-        const radiusScale = 0.55 + 0.45 * waterRatio
-        const flowScale = 0.25 + 0.75 * waterRatio
-        const scaledRadius = Math.max(brushState.radius * radiusScale, 1)
-        const scaledFlow = brushState.flow * flowScale
-        const baseDryness =
-          brushState.type === 'water' ? 0 : Math.min(1, Math.max(0, 1 - waterRatio))
-        const reservoirSolvent = baseDryness > 0.75 ? baseDryness : 0
-        const pasteActive = brushState.type === 'pigment' && brushState.pasteMode
-        // temporally disable low solvent mode
-        // const lowSolvent = pasteActive ? 1 : reservoirSolvent
-        const lowSolvent = 0
-        const dryness = pasteActive ? Math.max(baseDryness, 0.92) : baseDryness
-        const dryThreshold = lowSolvent > 0 ? 0.82 : undefined
-
-        const maskSettings = brushState.mask
-        const wetness = clamp01(waterRatio)
-        const jitter = (Math.random() - 0.5) * (maskSettings.rotationJitter ?? 0)
-        const rotation = heading + jitter
-        const pressureFactor = 1 + (maskSettings.pressureScale ?? 0) * (1 - wetness)
-        const maskScale: [number, number] = [
-          maskSettings.scale[0] * pressureFactor,
-          maskSettings.scale[1] * pressureFactor,
-        ]
-        const maskStrength = Math.min(
-          1,
-          maskSettings.strength * (0.65 + 0.35 * (1 - wetness)),
-        )
-
-        const color: [number, number, number] =
-          brushState.type === 'pigment'
-            ? [
-                brushState.color[0] * pigmentRatio,
-                brushState.color[1] * pigmentRatio,
-                brushState.color[2] * pigmentRatio,
-              ]
-            : [0, 0, 0]
-
-        sim.splat({
-          center: target,
-          radius: scaledRadius / size,
-          flow: scaledFlow,
-          type: brushState.type,
-          color,
-          dryness,
-          dryThreshold,
-          lowSolvent,
-          binderBoost: brushState.binderBoost,
-          pigmentBoost: brushState.pigmentBoost,
-          mask: {
-            texture: maskSettings.texture,
-            rotation,
-            scale: maskScale,
-            strength: maskStrength,
-          },
-        })
-
-        const areaFactor = (scaledRadius / size) ** 2
-        const flowContribution = scaledFlow * 0.5
-        const consumption = waterConsumption * (areaFactor + flowContribution)
-        reservoir.water = Math.max(0, reservoir.water - consumption)
-        if (brushState.type === 'pigment') {
-          const pigmentUse = pigmentConsumption * (areaFactor + flowContribution)
-          reservoir.pigment = Math.max(0, reservoir.pigment - pigmentUse)
-        }
-
-        reservoir.lastStamp = target
-        return true
-      }
-
-      if (forceStamp || !reservoir.lastStamp || !prevPos) {
-        if (stampOnce(uv)) {
-          reservoir.distanceSinceStamp = 0
-        }
-        return
-      }
-
-      if (segmentLength === 0) {
-        reservoir.distanceSinceStamp = prevDistance
-        return
-      }
-
-      const totalDistance = prevDistance + segmentLength
-      let lastMultiple = Math.floor(prevDistance / stampSpacing)
-      const kStart = lastMultiple + 1
-      const kEnd = Math.floor(totalDistance / stampSpacing)
-
-      if (kEnd < kStart) {
-        reservoir.distanceSinceStamp = totalDistance
-        return
-      }
-
-      // Subdivide the pointer segment so fast motion still emits evenly spaced splats.
-      for (let k = kStart; k <= kEnd; k++) {
-        const dist = k * stampSpacing
-        const t = (dist - prevDistance) / segmentLength
-        const target: [number, number] = [
-          prevPos[0] + dx * t,
-          prevPos[1] + dy * t,
-        ]
-
-        if (!stampOnce(target)) {
-          reservoir.distanceSinceStamp = totalDistance - lastMultiple * stampSpacing
-          return
-        }
-
-        lastMultiple = k
-      }
-
-      reservoir.distanceSinceStamp = totalDistance - lastMultiple * stampSpacing
-    }
-
-    // Pointer listeners manage painting lifecycle and prevent unwanted browser gestures.
     const handlePointerDown = (event: PointerEvent) => {
       if (event.button !== 0) return
-      paintingRef.current = true
-      reservoirRef.current = createReservoir(brushRef.current.type)
-      const uv = getUV(event)
-      const reservoir = reservoirRef.current
-      if (reservoir) {
-        reservoir.lastPos = uv
-        reservoir.distanceSinceStamp = stampSpacing
-        if (brushRef.current.type === 'spatter') {
-          reservoir.lastAngle = Math.random() * TAU
-        }
+      const brushState = brushRef.current
+      if (!brushState) return
+      if (!maskBuilderRef.current) {
+        return
       }
+      paintingRef.current = true
+      const uv = getUV(event)
+
+      if (brushState.type === 'spatter') {
+        const reservoir = createReservoir(brushState.type)
+        reservoir.lastPos = uv
+        reservoir.lastAngle = Math.random() * TAU
+        reservoirRef.current = reservoir
+        emitSpatter(uv, reservoir.lastAngle)
+      } else {
+        beginStroke(uv)
+      }
+
       event.preventDefault()
       try {
         el.setPointerCapture(event.pointerId)
       } catch {
-        // Pointer capture may be unsupported (e.g. Safari).
+        // ignore pointer capture failures
       }
-      splatAt(uv, true)
     }
 
     const handlePointerMove = (event: PointerEvent) => {
       if (!paintingRef.current) return
+      const brushState = brushRef.current
+      const reservoir = reservoirRef.current
+      if (!brushState || !reservoir) return
+
       event.preventDefault()
-      splatAt(getUV(event))
+      const uv = getUV(event)
+
+      if (brushState.type === 'spatter') {
+        const prev = reservoir.lastPos ?? uv
+        const dx = uv[0] - prev[0]
+        const dy = uv[1] - prev[1]
+        let heading = reservoir.lastAngle
+        if (Math.hypot(dx, dy) > 1e-5) {
+          heading = Math.atan2(dy, dx)
+          reservoir.lastAngle = heading
+        }
+        emitSpatter(uv, heading)
+        reservoir.lastPos = uv
+        return
+      }
+
+      addSegment(uv)
     }
 
     const endPaint = (event: PointerEvent) => {
       paintingRef.current = false
+      flushStroke(true)
       reservoirRef.current = null
       try {
         el.releasePointerCapture(event.pointerId)
@@ -483,6 +708,9 @@ const WatercolorViewport = ({
     el.addEventListener('contextmenu', cancelContext)
 
     return () => {
+      flushStroke(true)
+      reservoirRef.current = null
+      strokeRef.current = null
       el.removeEventListener('pointerdown', handlePointerDown)
       el.removeEventListener('pointermove', handlePointerMove)
       el.removeEventListener('pointerup', endPaint)

--- a/lib/watercolor/maskBuilder.ts
+++ b/lib/watercolor/maskBuilder.ts
@@ -1,0 +1,103 @@
+import * as THREE from 'three'
+
+import { createPingPong } from './targets'
+import { type PingPongTarget } from './types'
+
+export type MaskStamp = {
+  center: [number, number]
+  radius: number
+  rotation: number
+  scale: [number, number]
+  strength: number
+}
+
+export type MaskBuildResult = {
+  texture: THREE.Texture
+  target: THREE.WebGLRenderTarget
+}
+
+export class StrokeMaskBuilder {
+  private readonly renderer: THREE.WebGLRenderer
+  private readonly material: THREE.RawShaderMaterial
+  private readonly zeroMaterial: THREE.RawShaderMaterial
+  private readonly targets: PingPongTarget
+  private readonly scene: THREE.Scene
+  private readonly camera: THREE.OrthographicCamera
+  private readonly quad: THREE.Mesh<THREE.PlaneGeometry, THREE.RawShaderMaterial>
+
+  constructor(
+    renderer: THREE.WebGLRenderer,
+    material: THREE.RawShaderMaterial,
+    zeroMaterial: THREE.RawShaderMaterial,
+    size: number,
+    textureType: THREE.TextureDataType,
+  ) {
+    this.renderer = renderer
+    this.material = material
+    this.zeroMaterial = zeroMaterial
+    this.targets = createPingPong(size, textureType)
+    this.scene = new THREE.Scene()
+    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    this.quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material)
+    this.scene.add(this.quad)
+  }
+
+  dispose() {
+    this.quad.geometry.dispose()
+    this.targets.read.dispose()
+    this.targets.write.dispose()
+  }
+
+  build(stamps: MaskStamp[], brushMask: THREE.Texture): MaskBuildResult {
+    const previousTarget = this.renderer.getRenderTarget()
+    const previousAutoClear = this.renderer.autoClear
+
+    this.renderer.autoClear = false
+    this.clearTargets()
+
+    this.material.uniforms.uBristleMask.value = brushMask
+
+    if (stamps.length === 0) {
+      this.renderer.setRenderTarget(previousTarget)
+      this.renderer.autoClear = previousAutoClear
+      return { texture: this.targets.read.texture, target: this.targets.read }
+    }
+
+    for (const stamp of stamps) {
+      this.material.uniforms.uSource.value = this.targets.read.texture
+      this.material.uniforms.uCenter.value.set(stamp.center[0], stamp.center[1])
+      this.material.uniforms.uRadius.value = Math.max(stamp.radius, 1e-6)
+      this.material.uniforms.uMaskScale.value.set(stamp.scale[0], stamp.scale[1])
+      this.material.uniforms.uMaskRotation.value = stamp.rotation
+      this.material.uniforms.uMaskStrength.value = stamp.strength
+
+      this.renderMaterial(this.material, this.targets.write)
+      this.targets.swap()
+    }
+
+    this.renderer.setRenderTarget(previousTarget)
+    this.renderer.autoClear = previousAutoClear
+
+    return { texture: this.targets.read.texture, target: this.targets.read }
+  }
+
+  private clearTargets() {
+    this.renderMaterial(this.zeroMaterial, this.targets.read)
+    this.renderMaterial(this.zeroMaterial, this.targets.write)
+    // Ensure read buffer holds cleared state after swaps
+    this.targets.swap()
+    this.renderMaterial(this.zeroMaterial, this.targets.write)
+    this.targets.swap()
+  }
+
+  private renderMaterial(
+    material: THREE.RawShaderMaterial,
+    target: THREE.WebGLRenderTarget,
+  ) {
+    this.quad.material = material
+    this.renderer.setRenderTarget(target)
+    this.renderer.render(this.scene, this.camera)
+  }
+}
+
+export default StrokeMaskBuilder

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -2,16 +2,18 @@ import * as THREE from 'three'
 
 export type BrushType = 'water' | 'pigment' | 'spatter'
 
-export interface BrushMaskParams {
-  texture: THREE.Texture | null
-  scale: [number, number]
-  rotation: number
+export type BrushMaskKind = 'stroke' | 'droplet'
+
+export interface BrushMaskInstance {
+  kind: BrushMaskKind
+  texture: THREE.Texture
   strength: number
+  flowScale: number
+  velocity?: [number, number]
+  velocityStrength?: number
 }
 
 export interface BrushSettings {
-  center: [number, number]
-  radius: number
   flow: number
   type: BrushType
   color: [number, number, number]
@@ -21,7 +23,7 @@ export interface BrushSettings {
   binderBoost?: number
   pigmentBoost?: number
   depositBoost?: number
-  mask?: BrushMaskParams
+  mask: BrushMaskInstance
 }
 
 export type ChannelCoefficients = [number, number, number]
@@ -46,7 +48,6 @@ export interface ReservoirParams {
   pigmentCapacity: number
   waterConsumption: number
   pigmentConsumption: number
-  stampSpacing: number
 }
 
 export interface SurfaceTensionParams {
@@ -124,6 +125,7 @@ export type DiffuseWetMaterial = THREE.RawShaderMaterial & {
 
 export type MaterialMap = {
   zero: THREE.RawShaderMaterial
+  strokeMask: THREE.RawShaderMaterial
   splatHeight: THREE.RawShaderMaterial
   splatVelocity: THREE.RawShaderMaterial
   splatPigment: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- replace brush settings with mask metadata and add a stroke mask material/shader
- add a stroke mask builder and update simulation splat passes to sample precomputed masks
- refactor the viewport to batch pointer strokes into mask-driven splats and drop the stamp spacing control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7bbb481483269545741ce9a21fd4