### PR TITLE
Switch watercolor splats to mask-driven stroke pipeline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,7 +312,6 @@ export default function Home() {
     pigmentCapacity: { label: 'Pigment Charge', value: 11, min: 1, max: 20, step: 0.05 },
     waterConsumption: { label: 'Water Consumption', value: 0.28, min: 0.01, max: 1, step: 0.01 },
     pigmentConsumption: { label: 'Pigment Consumption', value: 0.22, min: 0.01, max: 1, step: 0.01 },
-    stampSpacing: { label: 'Stamp Spacing', value: 0.015, min: 0.001, max: 0.05, step: 0.001 },
   })
 
   const featureControls = useControls('Features', {
@@ -493,12 +492,11 @@ export default function Home() {
     threshold: number
     noiseScale: number
   }
-  const { waterCapacityWater, pigmentCapacity, waterConsumption, pigmentConsumption, stampSpacing } = reservoirControls as {
+  const { waterCapacityWater, pigmentCapacity, waterConsumption, pigmentConsumption } = reservoirControls as {
     waterCapacityWater: number;
     pigmentCapacity: number;
     waterConsumption: number;
     pigmentConsumption: number;
-    stampSpacing: number;
   }
   const pigmentIndex = tool === 'water' ? -1 : parseInt(tool.slice(-1), 10)
 
@@ -636,7 +634,6 @@ export default function Home() {
       pigmentCapacity,
       waterConsumption,
       pigmentConsumption,
-      stampSpacing,
     },
   }), [
     grav,
@@ -677,7 +674,6 @@ export default function Home() {
     pigmentCapacity,
     waterConsumption,
     pigmentConsumption,
-    stampSpacing,
   ])
 
   return (

--- a/lib/watercolor/maskBuilder.ts
+++ b/lib/watercolor/maskBuilder.ts
@@ -1,0 +1,103 @@
+import * as THREE from 'three'
+
+import { createPingPong } from './targets'
+import { type PingPongTarget } from './types'
+
+export type MaskStamp = {
+  center: [number, number]
+  radius: number
+  rotation: number
+  scale: [number, number]
+  strength: number
+}
+
+export type MaskBuildResult = {
+  texture: THREE.Texture
+  target: THREE.WebGLRenderTarget
+}
+
+export class StrokeMaskBuilder {
+  private readonly renderer: THREE.WebGLRenderer
+  private readonly material: THREE.RawShaderMaterial
+  private readonly zeroMaterial: THREE.RawShaderMaterial
+  private readonly targets: PingPongTarget
+  private readonly scene: THREE.Scene
+  private readonly camera: THREE.OrthographicCamera
+  private readonly quad: THREE.Mesh<THREE.PlaneGeometry, THREE.RawShaderMaterial>
+
+  constructor(
+    renderer: THREE.WebGLRenderer,
+    material: THREE.RawShaderMaterial,
+    zeroMaterial: THREE.RawShaderMaterial,
+    size: number,
+    textureType: THREE.TextureDataType,
+  ) {
+    this.renderer = renderer
+    this.material = material
+    this.zeroMaterial = zeroMaterial
+    this.targets = createPingPong(size, textureType)
+    this.scene = new THREE.Scene()
+    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    this.quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material)
+    this.scene.add(this.quad)
+  }
+
+  dispose() {
+    this.quad.geometry.dispose()
+    this.targets.read.dispose()
+    this.targets.write.dispose()
+  }
+
+  build(stamps: MaskStamp[], brushMask: THREE.Texture): MaskBuildResult {
+    const previousTarget = this.renderer.getRenderTarget()
+    const previousAutoClear = this.renderer.autoClear
+
+    this.renderer.autoClear = false
+    this.clearTargets()
+
+    this.material.uniforms.uBristleMask.value = brushMask
+
+    if (stamps.length === 0) {
+      this.renderer.setRenderTarget(previousTarget)
+      this.renderer.autoClear = previousAutoClear
+      return { texture: this.targets.read.texture, target: this.targets.read }
+    }
+
+    for (const stamp of stamps) {
+      this.material.uniforms.uSource.value = this.targets.read.texture
+      this.material.uniforms.uCenter.value.set(stamp.center[0], stamp.center[1])
+      this.material.uniforms.uRadius.value = Math.max(stamp.radius, 1e-6)
+      this.material.uniforms.uMaskScale.value.set(stamp.scale[0], stamp.scale[1])
+      this.material.uniforms.uMaskRotation.value = stamp.rotation
+      this.material.uniforms.uMaskStrength.value = stamp.strength
+
+      this.renderMaterial(this.material, this.targets.write)
+      this.targets.swap()
+    }
+
+    this.renderer.setRenderTarget(previousTarget)
+    this.renderer.autoClear = previousAutoClear
+
+    return { texture: this.targets.read.texture, target: this.targets.read }
+  }
+
+  private clearTargets() {
+    this.renderMaterial(this.zeroMaterial, this.targets.read)
+    this.renderMaterial(this.zeroMaterial, this.targets.write)
+    // Ensure read buffer holds cleared state after swaps
+    this.targets.swap()
+    this.renderMaterial(this.zeroMaterial, this.targets.write)
+    this.targets.swap()
+  }
+
+  private renderMaterial(
+    material: THREE.RawShaderMaterial,
+    target: THREE.WebGLRenderTarget,
+  ) {
+    this.quad.material = material
+    this.renderer.setRenderTarget(target)
+    this.renderer.render(this.scene, this.camera)
+  }
+}
+
+export default StrokeMaskBuilder

--- a/lib/watercolor/types.ts
+++ b/lib/watercolor/types.ts
@@ -2,16 +2,18 @@ import * as THREE from 'three'
 
 export type BrushType = 'water' | 'pigment' | 'spatter'
 
-export interface BrushMaskParams {
-  texture: THREE.Texture | null
-  scale: [number, number]
-  rotation: number
+export type BrushMaskKind = 'stroke' | 'droplet'
+
+export interface BrushMaskInstance {
+  kind: BrushMaskKind
+  texture: THREE.Texture
   strength: number
+  flowScale: number
+  velocity?: [number, number]
+  velocityStrength?: number
 }
 
 export interface BrushSettings {
-  center: [number, number]
-  radius: number
   flow: number
   type: BrushType
   color: [number, number, number]
@@ -21,7 +23,7 @@ export interface BrushSettings {
   binderBoost?: number
   pigmentBoost?: number
   depositBoost?: number
-  mask?: BrushMaskParams
+  mask: BrushMaskInstance
 }
 
 export type ChannelCoefficients = [number, number, number]
@@ -46,7 +48,6 @@ export interface ReservoirParams {
   pigmentCapacity: number
   waterConsumption: number
   pigmentConsumption: number
-  stampSpacing: number
 }
 
 export interface SurfaceTensionParams {
@@ -124,6 +125,7 @@ export type DiffuseWetMaterial = THREE.RawShaderMaterial & {
 
 export type MaterialMap = {
   zero: THREE.RawShaderMaterial
+  strokeMask: THREE.RawShaderMaterial
   splatHeight: THREE.RawShaderMaterial
   splatVelocity: THREE.RawShaderMaterial
   splatPigment: THREE.RawShaderMaterial


### PR DESCRIPTION
## Summary
- replace brush settings with mask metadata and add a stroke mask material/shader
- add a stroke mask builder and update simulation splat passes to sample precomputed masks
- refactor the viewport to batch pointer strokes into mask-driven splats and drop the stamp spacing control
- trigger mask builds and splats on each pointer move to keep strokes responsive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7bbb481483269545741ce9a21fd4